### PR TITLE
Build and publish container images

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ name: Code checks
 on:
   push:
     branches:
-      - main
+      - "main"
   pull_request:
 
 permissions:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Run "black --check"
         run: |
-          python -m black --check --verbose .
+          python -m black --check .
 
       - name: Run "isort --check"
         run: |
-          python -m isort --check --profile black --verbose .
+          python -m isort --check --profile black .

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -12,6 +12,9 @@ on:
     # disabled.
     # pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -72,7 +72,7 @@ jobs:
           push: true
           tags: |
             awsdx/sdx-controller:latest
-            ${{ steps.meta.outputs.tags }}
+            awsdx/sdx-controller:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # See https://github.com/docker/build-push-action
@@ -84,5 +84,5 @@ jobs:
           push: true
           tags: |
             awsdx/bapm-server:latest
-            ${{ steps.meta.outputs.tags }}
+            awsdx/bapm-server:${{ github.sha }}            
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -80,4 +80,5 @@ jobs:
           push: true
           tags: |
             awsdx/bapm-server:latest
-            awsdx/bapm-server:${{ github.sha }}
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - "main"
+    tags:
+      - "*"
   # Triggering the build/publish of container images on pull
   # requests should be here only for testing, keep "pull_request"
   # disabled.
@@ -55,4 +57,6 @@ jobs:
           context: ./bapm_server
           file: ./bapm_server/Dockerfile
           push: true
-          tags: awsdx/bapm-server:latest
+          tags: |
+            awsdx/bapm-server:latest
+            awsdx/bapm-server:${{ github.sha }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -20,15 +20,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # Secrets used here are set under "repository secrets" at
+      # https://github.com/atlanticwave-sdx/sdx-controller/settings/secrets/actions,
+      # 
+      # # See https://github.com/docker/login-action.
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Buildx is a Docker CLI plugin for extended build capabilities
+      # with BuildKit.
+      #
+      # See https://github.com/docker/setup-buildx-action.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      # See https://github.com/docker/build-push-action
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,3 +1,6 @@
+# A workflow to build and publish sdx-controllera container images.
+# See https://docs.docker.com/build/ci/github-actions/.
+
 name: Container images
 
 on:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,31 @@
+name: Container images
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/sdx-controller:latest

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -33,6 +33,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             awsdx/sdx-controller
+            awsdx/bapm-server
             # ghcr.io/username/app
           # generate Docker tags based on the following events/attributes
           tags: |
@@ -69,7 +70,10 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: awsdx/sdx-controller:latest
+          tags: |
+            awsdx/sdx-controller:latest
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       # See https://github.com/docker/build-push-action
       - name: Build and push

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Secrets used here are set under "repository secrets" at
       # https://github.com/atlanticwave-sdx/sdx-controller/settings/secrets/actions,
-      # 
+      #
       # # See https://github.com/docker/login-action.
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -45,3 +45,12 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: awsdx/sdx-controller:latest
+
+      # See https://github.com/docker/build-push-action
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: ./bapm_server
+          file: ./bapm_server/Dockerfile
+          push: true
+          tags: awsdx/bapm-server:latest

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -36,4 +36,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/sdx-controller:latest
+          tags: awsdx/sdx-controller:latest

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -17,20 +17,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Login to Docker Hub
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,11 +7,10 @@ on:
   push:
     branches:
       - "main"
-  # TODO: building *and* publishing container images on pull requests
-  # should be here only temporarily, while testing, because it
-  # probably makes more sense to publish images built off only merged
-  # code?
-  pull_request:
+    # Triggering the build/publish of container images on pull
+    # requests should be here only for testing, keep "pull_request"
+    # disabled.
+    # pull_request:
 
 jobs:
   build:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -24,6 +24,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # Collect metadata for container image tags
+      # See https://github.com/docker/metadata-action
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            awsdx/sdx-controller
+            # ghcr.io/username/app
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=pep440,pattern={{version}}
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
       # Secrets used here are set under "repository secrets" at
       # https://github.com/atlanticwave-sdx/sdx-controller/settings/secrets/actions,
       #

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,6 +7,11 @@ on:
   push:
     branches:
       - "main"
+  # TODO: building *and* publishing container images on pull requests
+  # should be here only temporarily, while testing, because it
+  # probably makes more sense to publish images built off only merged
+  # code?
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
       - "main"
-    # Triggering the build/publish of container images on pull
-    # requests should be here only for testing, keep "pull_request"
-    # disabled.
-    # pull_request:
+  # Triggering the build/publish of container images on pull
+  # requests should be here only for testing, keep "pull_request"
+  # disabled.
+  # pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       # See https://github.com/docker/build-push-action
-      - name: Build and push
+      - name: Build and push sdx-controller
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -76,7 +76,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       # See https://github.com/docker/build-push-action
-      - name: Build and push
+      - name: Build and push bapm-server
         uses: docker/build-push-action@v4
         with:
           context: ./bapm_server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,9 @@ name: Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - "main"
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/swagger_server/messaging/rpc_queue_producer.py
+++ b/swagger_server/messaging/rpc_queue_producer.py
@@ -50,7 +50,6 @@ class RpcProducer(object):
             self.response = body
 
     def call(self, body):
-
         self.response = None
         self.corr_id = str(uuid.uuid4())
         self.exchange_name = "connection"

--- a/swagger_server/utils/db_utils.py
+++ b/swagger_server/utils/db_utils.py
@@ -26,7 +26,7 @@ class DbUtils(object):
         )
 
         # Load the tables, create table if table does not.
-        for (name, table) in db_tables_tuples:
+        for name, table in db_tables_tuples:
             self.logger.debug("DB name: {}, table name: {}".format(name, table))
             if table in self.db:  # https://github.com/pudo/dataset/issues/281
                 self.logger.debug("Trying to load {} from DB".format(name))


### PR DESCRIPTION
Issue is #123.  Here are the changes:

- A new GitHub Actions workflow has been added, which will build and publish container images tagged `sdx-controller:latest` and `bapm-server:latest` to Docker Hub.  The images will appear under https://hub.docker.com/orgs/awsdx/repositories.  This workflow will trigger when a commit is made to `main`, which will usually happen when a PR is merged.
- A major version of black was released in January, which makes some different formatting changes than the previous version, so some Python code that is unrelated to this PR has been re-formatted.
- Minor adjustments in "test" and "checks" workflows, for consistency's sake.