### PR TITLE
Convert all mongodb keys to str

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: mongo:3.7
     container_name: mongodb
     ports:
-      - 27017:27017
+      - 27117:27017
     environment:
       # MONGO_INITDB_DATABASE: test
       MONGO_INITDB_ROOT_USERNAME: sdx
@@ -24,7 +24,7 @@ services:
       - 8080:8080
     environment:
       # update to sdx controller host name
-      - MONGODB_CONNSTRING=mongodb://sdx:passw@152.54.3.143:27017/
+      - MONGODB_CONNSTRING=mongodb://sdx:passw@152.54.3.143:27117/
       - SDX_HOST=aw-sdx-controller.renci.org
       - SDX_PORT=8080
       - SDX_VERSION=1.0.0

--- a/swagger_server/__main__.py
+++ b/swagger_server/__main__.py
@@ -1,19 +1,11 @@
 #!/usr/bin/env python3
 
-import argparse
 import json
 import logging
 import threading
-import time
-from optparse import OptionParser
 
 import connexion
-from sdx.datamodel import parsing, topologymanager, validation
-from sdx.datamodel.parsing.exceptions import DataModelException
-from sdx.datamodel.parsing.topologyhandler import TopologyHandler
-from sdx.datamodel.topologymanager.grenmlconverter import GrenmlConverter
 from sdx.datamodel.topologymanager.manager import TopologyManager
-from sdx.datamodel.validation.topologyvalidator import TopologyValidator
 
 from swagger_server import encoder
 from swagger_server.messaging.rpc_queue_consumer import *
@@ -137,10 +129,10 @@ def start_consumer(thread_queue, db_instance):
                 else:
                     logger.info("got message from MQ: " + str(msg))
             else:
-                db_instance.add_key_value_pair_to_db(MESSAGE_ID, msg)
+                db_instance.add_key_value_pair_to_db(str(MESSAGE_ID), msg)
                 logger.debug("Save to database complete.")
                 logger.debug("message ID:" + str(MESSAGE_ID))
-                value = db_instance.read_from_db(MESSAGE_ID)
+                value = db_instance.read_from_db(str(MESSAGE_ID))
                 logger.debug("got value from DB:")
                 logger.debug(value)
                 MESSAGE_ID += 1

--- a/swagger_server/utils/db_utils.py
+++ b/swagger_server/utils/db_utils.py
@@ -35,7 +35,7 @@ class DbUtils(object):
         self.logger.debug(f"DB {self.db_name} initialized")
 
     def add_key_value_pair_to_db(self, key, value):
-        obj = self.read_from_db(key)
+        obj = self.read_from_db(str(key))
         if obj is None:
             self.logger.debug(f"Adding key value pair {key}:{value} to DB.")
             return self.sdxdb[self.db_name][self.config_table_name].insert_one(


### PR DESCRIPTION
Fix Mongodb key issue. Mongodb requires keys to be string. Change Mongodb port to 27117. Since the Kytos MongoDB is using default port 27017.