### PR TITLE
Use Docker networking to access MongoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 /*.sqlite3-shm
 /*.sqlite3-wal
 
+/db/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - 8080:8080
     environment:
       # update to sdx controller host name
-      - MONGODB_CONNSTRING=mongodb://sdx:passw@localhost:27017/
+      - MONGODB_CONNSTRING=mongodb://sdx:passw@sdx-mongodb:27017/
       - SDX_HOST=aw-sdx-controller.renci.org
       - SDX_PORT=8080
       - SDX_VERSION=1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
   sdx-mongodb:
     image: mongo:3.7
     container_name: mongodb
-    ports:
-      - 27317:27017
     environment:
       # MONGO_INITDB_DATABASE: test
       MONGO_INITDB_ROOT_USERNAME: sdx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       MONGODB_DATA_DIR: /data/db
     volumes:
       # named volumes
-      - ~/mongodb:/data/db
+      - ./db:/data/db
 
   sdx-controller:
     image: sdx-controller

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
 
-  sdx-mongodb:
+  sdx-controller-mongodb:
     image: mongo:3.7
     container_name: mongodb
     environment:
@@ -22,7 +22,7 @@ services:
       - 8080:8080
     environment:
       # Use sdx-mongodb service specified above.
-      - MONGODB_CONNSTRING=mongodb://sdx:passw@sdx-mongodb:27017/
+      - MONGODB_CONNSTRING=mongodb://sdx:passw@sdx-controller-mongodb:27017/
       - SDX_HOST=aw-sdx-controller.renci.org
       - SDX_PORT=8080
       - SDX_VERSION=1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
 
-  my-mongodb:
+  sdx-mongodb:
     image: mongo:3.7
     container_name: mongodb
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      # Use sdx-mongodb service specified above.
+      # Use sdx-controller-mongodb service specified above.
       - MONGODB_CONNSTRING=mongodb://sdx:passw@sdx-controller-mongodb:27017/
       - SDX_HOST=aw-sdx-controller.renci.org
       - SDX_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - 8080:8080
     environment:
       # update to sdx controller host name
-      - MONGODB_CONNSTRING=mongodb://sdx:passw@152.54.3.143:27317/
+      - MONGODB_CONNSTRING=mongodb://sdx:passw@localhost:27317/
       - SDX_HOST=aw-sdx-controller.renci.org
       - SDX_PORT=8080
       - SDX_VERSION=1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      # update to sdx controller host name
+      # Use sdx-mongodb service specified above.
       - MONGODB_CONNSTRING=mongodb://sdx:passw@sdx-mongodb:27017/
       - SDX_HOST=aw-sdx-controller.renci.org
       - SDX_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   sdx-controller:
     image: sdx-controller
+    container_name: sdx-controller
     tty: true
     build: ./
     ports:
@@ -40,6 +41,7 @@ services:
 
   bapm-server:
     image: bapm-server
+    container_name: bapm-server
     # network_mode: "host"
     tty: true
     build: ./bapm_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.8'
 
 services:
 
+  # See https://hub.docker.com/_/mongo/ for documentation about
+  # MongoDB Docker images.
   sdx-controller-mongodb:
     image: mongo:3.7
     container_name: mongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,11 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: passw
       MONGODB_DATA_DIR: /data/db
     volumes:
-      # named volumes
-      - ./db:/data/db
+      # Named volumes. The 'Z' option tells Docker to label the
+      # content with a private unshared label. Private volumes can
+      # only be used by the current container.  See
+      # https://docs.docker.com/engine/reference/commandline/run/
+      - ./db:/data/db:Z
 
   sdx-controller:
     image: sdx-controller

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - 8080:8080
     environment:
       # update to sdx controller host name
-      - MONGODB_CONNSTRING=mongodb://sdx:passw@localhost:27317/
+      - MONGODB_CONNSTRING=mongodb://sdx:passw@localhost:27017/
       - SDX_HOST=aw-sdx-controller.renci.org
       - SDX_PORT=8080
       - SDX_VERSION=1.0.0


### PR DESCRIPTION
Issue is #147.

See https://docs.docker.com/compose/networking/:

> By default Compose sets up a single network for your app. Each container for a service joins the default network and is both reachable by other containers on that network, and discoverable by them at a hostname identical to the container name.

Meaning, we don't have to publish MongoDB port.