### PR TITLE
Clean up imports

### DIFF
--- a/bapm_server/__main__.py
+++ b/bapm_server/__main__.py
@@ -6,7 +6,7 @@ import os
 
 from elasticsearch import Elasticsearch
 
-from bapm_consumer import *
+from bapm_consumer import BAPMConsumer
 
 logger = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)

--- a/bapm_server/__main__.py
+++ b/bapm_server/__main__.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import os
+import threading
+from queue import Queue
 
 from elasticsearch import Elasticsearch
 

--- a/bapm_server/bapm_consumer.py
+++ b/bapm_server/bapm_consumer.py
@@ -4,7 +4,6 @@ import functools
 import logging
 import os
 import threading
-import time
 from queue import Queue
 
 import pika

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ src_paths = ["setup.py", "swagger_server", "bapm_server", "tests"]
 
 [tool.coverage.run]
 branch = true
-omit = [ "tests/*", "swagger_server/test/" ]
+omit = [ "tests/*", "swagger_server/test/*" ]
 relative_files = true
 
 # The section below will let us have relative paths in test coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,22 @@ src_paths = ["setup.py", "swagger_server", "bapm_server", "tests"]
 [tool.isort]
 profile = "black"
 src_paths = ["setup.py", "swagger_server", "bapm_server", "tests"]
+
+[tool.coverage.run]
+branch = true
+# source_pkgs = sdx.pce
+omit = [ "tests/*", "swagger_server/test/" ]
+relative_files = true
+
+# The section below will let us have relative paths in test coverage
+# report. See https://hynek.me/articles/testing-packaging/
+[tool.coverage.paths]
+source = [
+    # In checkouts.
+    "swagger_server/",
+    "bapm_server/",
+    # In installed paths.
+    "**/site-packages/",
+    # In tox environments.
+    ".tox/**/site-packages/",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ src_paths = ["setup.py", "swagger_server", "bapm_server", "tests"]
 
 [tool.coverage.run]
 branch = true
-# source_pkgs = sdx.pce
 omit = [ "tests/*", "swagger_server/test/" ]
 relative_files = true
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-import sys
 
 from setuptools import find_packages, setup
 

--- a/swagger_server/__main__.py
+++ b/swagger_server/__main__.py
@@ -165,8 +165,6 @@ def main():
     # Run swagger in a thread
     threading.Thread(target=lambda: app.run(port=8080)).start()
 
-    DB_NAME = os.environ.get("DB_NAME") + ".sqlite3"
-
     # Get DB connection and tables set up.
     db_instance = DbUtils()
     db_instance.initialize_db()

--- a/swagger_server/__main__.py
+++ b/swagger_server/__main__.py
@@ -8,8 +8,8 @@ import connexion
 from sdx.pce.topology.manager import TopologyManager
 
 from swagger_server import encoder
-from swagger_server.messaging.rpc_queue_consumer import *
-from swagger_server.utils.db_utils import *
+from swagger_server.messaging.rpc_queue_consumer import RpcConsumer
+from swagger_server.utils.db_utils import DbUtils
 
 logger = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)

--- a/swagger_server/__main__.py
+++ b/swagger_server/__main__.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import threading
+from queue import Queue
 
 import connexion
 from sdx.pce.topology.manager import TopologyManager

--- a/swagger_server/controllers/authorization_controller.py
+++ b/swagger_server/controllers/authorization_controller.py
@@ -1,4 +1,3 @@
-
 """
 controller generated to handled auth operation described at:
 https://connexion.readthedocs.io/en/latest/security.html

--- a/swagger_server/controllers/authorization_controller.py
+++ b/swagger_server/controllers/authorization_controller.py
@@ -1,4 +1,3 @@
-from typing import List
 
 """
 controller generated to handled auth operation described at:

--- a/swagger_server/controllers/connection_controller.py
+++ b/swagger_server/controllers/connection_controller.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 
 import connexion
 from sdx.pce.load_balancing.te_solver import TESolver

--- a/swagger_server/controllers/link_controller.py
+++ b/swagger_server/controllers/link_controller.py
@@ -1,7 +1,4 @@
-import connexion
-import six
 
-from swagger_server import util
 
 
 def get_link():  # noqa: E501

--- a/swagger_server/controllers/link_controller.py
+++ b/swagger_server/controllers/link_controller.py
@@ -1,6 +1,3 @@
-
-
-
 def get_link():  # noqa: E501
     """get an existing link
 

--- a/swagger_server/controllers/node_controller.py
+++ b/swagger_server/controllers/node_controller.py
@@ -1,7 +1,4 @@
-import connexion
-import six
 
-from swagger_server import util
 
 
 def get_node():  # noqa: E501

--- a/swagger_server/controllers/node_controller.py
+++ b/swagger_server/controllers/node_controller.py
@@ -1,6 +1,3 @@
-
-
-
 def get_node():  # noqa: E501
     """get an existing node
 

--- a/swagger_server/controllers/topology_controller.py
+++ b/swagger_server/controllers/topology_controller.py
@@ -1,14 +1,8 @@
 import json
-import os
-from queue import Queue
 
-import connexion
-import six
 from sdx.pce.topology.grenmlconverter import GrenmlConverter
 from sdx.pce.topology.manager import TopologyManager
 
-from swagger_server import util
-from swagger_server.models.topology import Topology  # noqa: E501
 from swagger_server.utils.db_utils import *
 
 # Get DB connection and tables set up.

--- a/swagger_server/controllers/topology_controller.py
+++ b/swagger_server/controllers/topology_controller.py
@@ -3,7 +3,7 @@ import json
 from sdx.pce.topology.grenmlconverter import GrenmlConverter
 from sdx.pce.topology.manager import TopologyManager
 
-from swagger_server.utils.db_utils import *
+from swagger_server.utils.db_utils import DbUtils
 
 # Get DB connection and tables set up.
 db_instance = DbUtils()

--- a/swagger_server/controllers/user_controller.py
+++ b/swagger_server/controllers/user_controller.py
@@ -1,7 +1,5 @@
 import connexion
-import six
 
-from swagger_server import util
 from swagger_server.models.user import User  # noqa: E501
 
 

--- a/swagger_server/test/test_connection_controller.py
+++ b/swagger_server/test/test_connection_controller.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import unittest
 
 from flask import json
-from six import BytesIO
 
 from swagger_server.models.connection import Connection  # noqa: E501
 from swagger_server.test import BaseTestCase

--- a/swagger_server/test/test_link_controller.py
+++ b/swagger_server/test/test_link_controller.py
@@ -2,8 +2,6 @@
 
 from __future__ import absolute_import
 
-from flask import json
-from six import BytesIO
 
 from swagger_server.test import BaseTestCase
 

--- a/swagger_server/test/test_link_controller.py
+++ b/swagger_server/test/test_link_controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-
 from swagger_server.test import BaseTestCase
 
 

--- a/swagger_server/test/test_node_controller.py
+++ b/swagger_server/test/test_node_controller.py
@@ -2,8 +2,6 @@
 
 from __future__ import absolute_import
 
-from flask import json
-from six import BytesIO
 
 from swagger_server.test import BaseTestCase
 

--- a/swagger_server/test/test_node_controller.py
+++ b/swagger_server/test/test_node_controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-
 from swagger_server.test import BaseTestCase
 
 

--- a/swagger_server/test/test_topology_controller.py
+++ b/swagger_server/test/test_topology_controller.py
@@ -2,10 +2,7 @@
 
 from __future__ import absolute_import
 
-from flask import json
-from six import BytesIO
 
-from swagger_server.models.topology import Topology  # noqa: E501
 from swagger_server.test import BaseTestCase
 
 

--- a/swagger_server/test/test_topology_controller.py
+++ b/swagger_server/test/test_topology_controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-
 from swagger_server.test import BaseTestCase
 
 

--- a/swagger_server/test/test_user_controller.py
+++ b/swagger_server/test/test_user_controller.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 
 from flask import json
-from six import BytesIO
 
 from swagger_server.models.user import User  # noqa: E501
 from swagger_server.test import BaseTestCase

--- a/tests/test_Solver.py
+++ b/tests/test_Solver.py
@@ -2,9 +2,8 @@ import json
 import pathlib
 import unittest
 
-from sdx.datamodel.parsing.exceptions import DataModelException
 from sdx.pce.load_balancing.te_solver import TESolver
-from sdx.pce.models import ConnectionRequest, ConnectionSolution, TrafficMatrix
+from sdx.pce.models import ConnectionSolution
 from sdx.pce.topology.temanager import TEManager
 
 


### PR DESCRIPTION
Issue is #184.  These are the changes:

- Remove all unused imports.
- Avoid some wildcard imports, and explicitly import classes instead.
- Import some modules that are used rarely (because they are used by `__main__` of those modules, which we rarely invoke)
- Remove an unused variable.

These were found by the [ruff](https://github.com/astral-sh/ruff) linter, and I am considering adding ruff checks as a CI step.  Ruff reported some more errors, about which I will follow-up separately.

This PR also carries an unrelated change caused by coveralls triggering a goofy error: omit test modules from coverage measurement.  It causes the coverage report to drop, but we will also get a more "honest" coverage report.  I am planning on working on improving test coverage, so this would help.