### PR TITLE
link failure handling, part 1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,17 +45,17 @@ services:
       - DB_NAME=${DB_NAME}
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
 
-  bapm-server-service:
-    image: bapm-server
-    tty: true
-    build: ./bapm_server
-    environment:
-      - ES_HOST=${ES_HOST}
-      - ES_PORT=${ES_PORT}
-      - BAPM_MQ_HOST=${BAPM_MQ_HOST}
-      - BAPM_EXCHANGE=${BAPM_EXCHANGE}
-      - BAPM_QUEUE=${BAPM_QUEUE}
-      - BAPM_ROUTING_KEY=${BAPM_ROUTING_KEY}
+  # bapm-server-service:
+  #   image: bapm-server
+  #   tty: true
+  #   build: ./bapm_server
+  #   environment:
+  #     - ES_HOST=${ES_HOST}
+  #     - ES_PORT=${ES_PORT}
+  #     - BAPM_MQ_HOST=${BAPM_MQ_HOST}
+  #     - BAPM_EXCHANGE=${BAPM_EXCHANGE}
+  #     - BAPM_QUEUE=${BAPM_QUEUE}
+  #     - BAPM_ROUTING_KEY=${BAPM_ROUTING_KEY}
 
 volumes:
   mongodb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,17 +45,17 @@ services:
       - DB_NAME=${DB_NAME}
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
 
-  # bapm-server-service:
-  #   image: bapm-server
-  #   tty: true
-  #   build: ./bapm_server
-  #   environment:
-  #     - ES_HOST=${ES_HOST}
-  #     - ES_PORT=${ES_PORT}
-  #     - BAPM_MQ_HOST=${BAPM_MQ_HOST}
-  #     - BAPM_EXCHANGE=${BAPM_EXCHANGE}
-  #     - BAPM_QUEUE=${BAPM_QUEUE}
-  #     - BAPM_ROUTING_KEY=${BAPM_ROUTING_KEY}
+  bapm-server-service:
+    image: bapm-server
+    tty: true
+    build: ./bapm_server
+    environment:
+      - ES_HOST=${ES_HOST}
+      - ES_PORT=${ES_PORT}
+      - BAPM_MQ_HOST=${BAPM_MQ_HOST}
+      - BAPM_EXCHANGE=${BAPM_EXCHANGE}
+      - BAPM_QUEUE=${BAPM_QUEUE}
+      - BAPM_ROUTING_KEY=${BAPM_ROUTING_KEY}
 
 volumes:
   mongodb:

--- a/swagger_server/__main__.py
+++ b/swagger_server/__main__.py
@@ -13,8 +13,8 @@ from sdx_pce.topology.temanager import TEManager
 
 from swagger_server import encoder
 from swagger_server.messaging.rpc_queue_consumer import RpcConsumer
-from swagger_server.utils.db_utils import DbUtils
 from swagger_server.models.simple_link import SimpleLink
+from swagger_server.utils.db_utils import DbUtils
 
 logger = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)
@@ -37,13 +37,16 @@ def find_between(s, first, last):
     except ValueError:
         return ""
 
+
 def _remove_connection(connection, db_instance):
     # call pce to remove connection
     pass
 
+
 def _place_connection(connection, db_instance):
     # call pce to generate breakdown, and place connection
     pass
+
 
 def _handle_link_failure(db_instance, msg_json):
     logger.debug("Handling connections that contain failed link.")
@@ -62,14 +65,14 @@ def _handle_link_failure(db_instance, msg_json):
     for link in msg_json["link_failure"]:
         port_list = []
         if "ports" not in link:
-            continue 
+            continue
         for port in link["ports"]:
             if "id" not in port:
                 continue
             port_list.append(port["id"])
 
         simple_link = SimpleLink(port_list).to_string()
-        
+
         if simple_link in link_connections_dict:
             logger.debug("Found failed link record!")
             connections = link_connections_dict[simple_link]
@@ -82,10 +85,10 @@ def _handle_link_failure(db_instance, msg_json):
                 link_connections_dict[simple_link].append(connection)
                 logger.debug("Placed connection:")
                 logger.debug(connection)
-    
+
     db_instance.add_key_value_pair_to_db(
-                "link_connections_dict", json.dumps(link_connections_dict)
-            )
+        "link_connections_dict", json.dumps(link_connections_dict)
+    )
 
 
 def process_lc_json_msg(
@@ -158,7 +161,6 @@ def start_consumer(thread_queue, db_instance):
 
     latest_topo = {}
     domain_list = []
-
 
     if db_instance.read_from_db("domain_list") is not None:
         domain_list = db_instance.read_from_db("domain_list")["domain_list"]

--- a/swagger_server/controllers/connection_controller.py
+++ b/swagger_server/controllers/connection_controller.py
@@ -6,8 +6,8 @@ from sdx_pce.load_balancing.te_solver import TESolver
 from sdx_pce.topology.temanager import TEManager
 
 from swagger_server.messaging.topic_queue_producer import TopicQueueProducer
-from swagger_server.utils.db_utils import DbUtils
 from swagger_server.models.simple_link import SimpleLink
+from swagger_server.utils.db_utils import DbUtils
 
 LOG_FORMAT = (
     "%(levelname) -10s %(asctime)s %(name) -30s %(funcName) "
@@ -162,9 +162,7 @@ def place_connection(body):
     )
 
     if link_connections_dict_json:
-        link_connections_dict = json.loads(
-            link_connections_dict_json
-        )
+        link_connections_dict = json.loads(link_connections_dict_json)
     else:
         link_connections_dict = {}
 
@@ -179,7 +177,7 @@ def place_connection(body):
 
             if simple_link not in link_connections_dict:
                 link_connections_dict[simple_link] = []
-            
+
             if body not in link_connections_dict[simple_link]:
                 link_connections_dict[simple_link].append(body)
 

--- a/swagger_server/controllers/connection_controller.py
+++ b/swagger_server/controllers/connection_controller.py
@@ -119,7 +119,7 @@ def place_connection(body):
         else:
             # Get the actual thing minus the Mongo ObjectID.
             curr_topo_str = curr_topo.get(lc)
-            # Just print a substring, not the whole thing.
+            # Just log a substring, not the whole thing.
             logger.debug(f"Read {lc} from DB: {curr_topo_str[0:50]}...")
 
         curr_topo_json = json.loads(curr_topo_str)
@@ -176,8 +176,6 @@ def place_connection(body):
 
         if port_list:
             simple_link = SimpleLink(port_list).to_string()
-            print("---simple_link")
-            print(simple_link)
 
             if simple_link not in link_connections_dict:
                 link_connections_dict[simple_link] = []
@@ -206,9 +204,5 @@ def place_connection(body):
         )
         producer.call(json.dumps(link))
         producer.stop_keep_alive()
-
-    print("--FINAL link_connections_dict--")
-    link_dict = db_instance.read_from_db("link_connections_dict")["link_connections_dict"]
-    print(json.loads(link_dict))
 
     return "Connection published"

--- a/swagger_server/models/simple_link.py
+++ b/swagger_server/models/simple_link.py
@@ -1,5 +1,6 @@
 from typing import List
 
+
 class SimpleLink:
     def __init__(self, ports: List[str]):
         self._ports = ports
@@ -13,7 +14,7 @@ class SimpleLink:
         :rtype: List[Port]
         """
         return self._ports
-    
+
     @ports.setter
     def ports(self, ports: List[str]):
         """Sets the ports of this Link.
@@ -31,4 +32,4 @@ class SimpleLink:
         self._ports.sort()
 
     def to_string(self):
-        return ','.join(self._ports)
+        return ",".join(self._ports)

--- a/swagger_server/models/simple_link.py
+++ b/swagger_server/models/simple_link.py
@@ -1,0 +1,34 @@
+from typing import List
+
+class SimpleLink:
+    def __init__(self, ports: List[str]):
+        self._ports = ports
+
+    @property
+    def ports(self) -> List[str]:
+        """Gets the ports of this Link.
+
+
+        :return: The ports of this Link.
+        :rtype: List[Port]
+        """
+        return self._ports
+    
+    @ports.setter
+    def ports(self, ports: List[str]):
+        """Sets the ports of this Link.
+
+
+        :param ports: The ports of this Link.
+        :type ports: List[Port]
+        """
+        if ports is None:
+            raise ValueError(
+                "Invalid value for `ports`, must not be `None`"
+            )  # noqa: E501
+
+        self._ports = ports
+        self._ports.sort()
+
+    def to_string(self):
+        return ','.join(self._ports)

--- a/swagger_server/utils/db_utils.py
+++ b/swagger_server/utils/db_utils.py
@@ -38,13 +38,13 @@ class DbUtils(object):
         key = str(key)
         obj = self.read_from_db(key)
         if obj is None:
-            self.logger.debug(f"Adding key value pair {key}:{value} to DB.")
+            # self.logger.debug(f"Adding key value pair {key}:{value} to DB.")
             return self.sdxdb[self.db_name][self.config_table_name].insert_one(
                 {key: value}
             )
 
         query = {"_id": obj["_id"]}
-        self.logger.debug(f"Updating DB entry {key}:{value}.")
+        # self.logger.debug(f"Updating DB entry {key}:{value}.")
         result = self.sdxdb[self.db_name][self.config_table_name].replace_one(
             query, {key: value}
         )


### PR DESCRIPTION
Relates to https://github.com/atlanticwave-sdx/sdx-controller/issues/161
This adds the first few items to handle link failure. The SDX controller maintains a link-connection dict in the database. When a connection is placed, the link and corresponding connection request is added to the dict. The link is formatted as a serialized list of ports (sorted by name).

When failure request comes from the LC, SDX controller first looks at the dict, if a key (link) is found, SDX will first call pce to remove the connection, then do path computation, and place the connection again.