### PR TITLE
Avoid busy wait in bapm_server

### DIFF
--- a/bapm_server/__main__.py
+++ b/bapm_server/__main__.py
@@ -34,14 +34,13 @@ def start_consumer(thread_queue, es):
     t1.start()
 
     while True:
-        if not thread_queue.empty():
-            data = thread_queue.get()
-            if is_json(data):
-                resp = es.index(index="measurement-index", id=MSG_ID, document=data)
-                print(resp["result"])
-                MSG_ID += 1
-            else:
-                logger.info("Received non-JSON data. Not saving to ElasticSearch.")
+        data = thread_queue.get()
+        if is_json(data):
+            resp = es.index(index="measurement-index", id=MSG_ID, document=data)
+            print(resp["result"])
+            MSG_ID += 1
+        else:
+            logger.info("Received non-JSON data. Not saving to ElasticSearch.")
 
 
 def main():


### PR DESCRIPTION
By default, [Queue.get()](https://docs.python.org/3/library/queue.html#queue.Queue.get) is a blocking call; no need of checking if the queue is non-empty in a loop.

Resolves #199.  I believe this is similar to issue #33, which was resolved by PR #175.