### PR TITLE
Docker and app fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN --mount=source=.git,target=.git,type=bind \
 EXPOSE 8080
 
 ENTRYPOINT ["python3"]
-CMD ["-m", "uvicorn", "sdx_controller.app:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["-m", "uvicorn", "sdx_controller.app:asgi_app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN --mount=source=.git,target=.git,type=bind \
 EXPOSE 8080
 
 ENTRYPOINT ["python3"]
-CMD ["-m", "uvicorn", "sdx_controller.app:app"]
+CMD ["-m", "uvicorn", "sdx_controller.app:asgi_app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN --mount=source=.git,target=.git,type=bind \
 EXPOSE 8080
 
 ENTRYPOINT ["python3"]
-CMD ["-m", "uvicorn", "sdx_controller.app:asgi_app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["-m", "uvicorn", "sdx_controller.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN --mount=source=.git,target=.git,type=bind \
 EXPOSE 8080
 
 ENTRYPOINT ["python3"]
-CMD ["-m", "uvicorn", "sdx_controller.app:asgi_app"]
+CMD ["-m", "uvicorn", "sdx_controller.app:asgi_app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ with Docker:
 
 ```console
 $ docker run --rm -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:latest
-$ docker run --rm -d --name mongo -p 27017:27017 -e MONGO_INITDB_ROOT_USERNAME=guest -e MONGO_INITDB_ROOT_PASSWORD=guest mongo:3.7
+$ docker run --rm -d --name mongo -p 27017:27017 -e MONGO_INITDB_ROOT_USERNAME=guest -e MONGO_INITDB_ROOT_PASSWORD=guest mongo:7.0.5
 ```
 
 Some environment variables are expected to be set for the tests to

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ $ python3 -m venv venv --upgrade-deps
 $ source ./venv/bin/activate
 $ pip3 install [--editable] .
 $ source .env
-$ python3 -m sdx_controller
+$ flask --app sdx_controller.app:app run --debug
 ```
 
 ### Test topology files and connection requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "jsonschema == 3.2.0",
     "connexion[swagger-ui] >= 2.14.1",
+    "asgiref >= 3.7.2",
     "python_dateutil >= 2.8",
     "setuptools >= 21.0.0",
     "pika >= 1.2.0",

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -37,11 +37,11 @@ def create_app(run_listener: bool = True):
     Create a connexion app.
 
     The object returned is a Connexion App, which in turn contains a
-    Flask app, that we can run either with Flask or WSGI server such
-    as uvicorn::
+    Flask app, that we can run either with Flask or an ASGI server
+    such as uvicorn::
 
-        $ flask run sdx_server.app
-        $ uvicorn run sdx_server.app:app
+        $ flask run sdx_server.app:app
+        $ uvicorn run sdx_server.app:asgi_app
 
     We also create a thread that subscribes to our message queue.
     Occasionally it might be useful not to start the thread (such as

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -66,5 +66,7 @@ def create_app(run_listener: bool = True):
 
     if run_listener:
         create_rpc_thread(app)
+    else:
+        app.rpc_consumer = None
 
     return app

--- a/sdx_controller/app.py
+++ b/sdx_controller/app.py
@@ -19,8 +19,9 @@ app = application.app
 # uvicorn or hypercorn), like so:
 #
 #     $ uvicorn sdx_controller.app:asgi_app --host 0.0.0.0 --port 8080
-# 
+#
 asgi_app = WsgiToAsgi(app)
+
 
 @atexit.register
 def on_app_exit():
@@ -30,7 +31,8 @@ def on_app_exit():
     We run a message queue consumer in a separate thread, and here we
     signal the thread that we're exiting.
     """
-    application.rpc_consumer.stop_threads()
+    if application.rpc_consumer:
+        application.rpc_consumer.stop_threads()
 
 
 if __name__ == "__main__":

--- a/sdx_controller/app.py
+++ b/sdx_controller/app.py
@@ -23,9 +23,11 @@ app = application.app
 #
 asgi_app = WsgiToAsgi(app)
 
+
 @app.route("/", methods=["GET"])
 def index():
     return redirect("/SDX-Controller/1.0.0/ui/")
+
 
 @atexit.register
 def on_app_exit():

--- a/sdx_controller/app.py
+++ b/sdx_controller/app.py
@@ -1,6 +1,7 @@
 import atexit
 
 from asgiref.wsgi import WsgiToAsgi
+from flask import redirect
 
 from sdx_controller import create_app
 
@@ -22,6 +23,9 @@ app = application.app
 #
 asgi_app = WsgiToAsgi(app)
 
+@app.route("/", methods=["GET"])
+def index():
+    return redirect("/SDX-Controller/1.0.0/ui/")
 
 @atexit.register
 def on_app_exit():

--- a/sdx_controller/app.py
+++ b/sdx_controller/app.py
@@ -4,8 +4,15 @@ from asgiref.wsgi import WsgiToAsgi
 
 from sdx_controller import create_app
 
+# This is a `connexion.apps.flask_app.FlaskApp` that we created using
+# connexion.App().
 application = create_app()
+
+# This is a `flask.app.Flask` object.
 app = application.app
+
+# We use WsgiToAsgi adapter so that we can use an ASGI server (such as
+# uvicorn or hypercorn).
 asgi_app = WsgiToAsgi(app)
 
 @atexit.register

--- a/sdx_controller/app.py
+++ b/sdx_controller/app.py
@@ -1,10 +1,12 @@
 import atexit
 
+from asgiref.wsgi import WsgiToAsgi
+
 from sdx_controller import create_app
 
 application = create_app()
 app = application.app
-
+asgi_app = WsgiToAsgi(app)
 
 @atexit.register
 def on_app_exit():

--- a/sdx_controller/app.py
+++ b/sdx_controller/app.py
@@ -8,12 +8,10 @@ from sdx_controller import create_app
 # connexion.App().
 application = create_app()
 
-# This is a `flask.app.Flask` object.
-app = application.app
-
-# We use WsgiToAsgi adapter so that we can use an ASGI server (such as
+# The application above contains a `flask.app.Flask` object.  We use
+# WsgiToAsgi adapter so that we can use an ASGI server (such as
 # uvicorn or hypercorn).
-asgi_app = WsgiToAsgi(app)
+app = WsgiToAsgi(application.app)
 
 @atexit.register
 def on_app_exit():

--- a/sdx_controller/app.py
+++ b/sdx_controller/app.py
@@ -8,10 +8,19 @@ from sdx_controller import create_app
 # connexion.App().
 application = create_app()
 
-# The application above contains a `flask.app.Flask` object.  We use
-# WsgiToAsgi adapter so that we can use an ASGI server (such as
-# uvicorn or hypercorn).
-app = WsgiToAsgi(application.app)
+# The application above contains a `flask.app.Flask` object.  We can
+# run the app using flask, like so:
+#
+#     $ flask --app sdx_controller.app:app run --debug
+#
+app = application.app
+
+# We use WsgiToAsgi adapter so that we can use an ASGI server (such as
+# uvicorn or hypercorn), like so:
+#
+#     $ uvicorn sdx_controller.app:asgi_app --host 0.0.0.0 --port 8080
+# 
+asgi_app = WsgiToAsgi(app)
 
 @atexit.register
 def on_app_exit():


### PR DESCRIPTION
Resolves #217.  Changes:

- Use [asgiref.wsgi.WsgiToAsgi adapter](https://flask.palletsprojects.com/en/3.0.x/deploying/asgi/) so that uvicorn runs correctly.
- Bind to `0.0.0.0:8080` rather than `localhost:8080` so that the port is available outside of the container.
- Update README and comments.
- Add a redirect from "/" path to Swagger UI path, which seems like a sane default for now.