### PR TITLE
Fix return for place connection

### DIFF
--- a/env.template
+++ b/env.template
@@ -33,3 +33,6 @@ export BAPM_MQ_HOST="amqp://guest:guest@aw-sdx-monitor.renci.org:5672/%2F"
 export BAPM_EXCHANGE="measurement"
 export BAPM_QUEUE="sdx_q_measurement"
 export BAPM_ROUTING_KEY="measurement.bapm"
+
+# Save log to file
+export LOG_FILE="sdx-controller.log"

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -157,7 +157,7 @@ class ConnectionHandler:
 
         breakdown = temanager.generate_connection_breakdown(solution)
         self._send_breakdown_to_lc(breakdown, connection_request)
-        return self._send_breakdown_to_lc(breakdown, connection_request)
+        return "Successfully placed connection", 200
 
     def handle_link_failure(self, msg_json):
         logger.debug("---Handling connections that contain failed link.---")


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/230

Fix return for place_connection(). In the future, the connection ID should be returned, to be used when we delete connection. Will address in a follow up PR.