### PR TITLE
Use tox-docker to run services when testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 tox coveralls
+          python -m pip install flake8 coveralls .[test]
 
       - name: Lint with flake8
         run: |
@@ -70,9 +70,9 @@ jobs:
           # is is 88 chars wide.
           python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
 
-      - name: Test with tox
+      - name: Run tests
         run: |
-          python -m tox
+          python -m pytest
         env:
           SDX_HOST: 'localhost'
           SDX_PORT: '8080'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 coveralls .[test]
+          python -m pip install flake8 .[test]
 
       - name: Lint with flake8
         run: |
@@ -72,7 +72,10 @@ jobs:
 
       - name: Run tests
         run: |
+          # Run tests and collect coverage data.
           python -m pytest
+          # Generate LCOV format coverage data for coveralls.
+          python -m coverage lcov -o coverage.lcov
         env:
           SDX_HOST: 'localhost'
           SDX_PORT: '8080'
@@ -86,12 +89,11 @@ jobs:
         timeout-minutes: 3
 
       - name: Send coverage data to coveralls.io
-        run: |
-          python -m coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-          COVERALLS_PARALLEL: true
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: run-${{ join(matrix.*, '-') }}
+          file: coverage.lcov
+          parallel: true
 
   finalize:
     name: finalize

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ $ pip install tox tox-docker
 $ tox
 ```
 
+If you want to examine Docker logs after the test suite has exited,
+you can run `tox --docker-dont-stop [mongo|rabbitmq]`, and then use
+`docker logs <container-name>`.
+
 If you want to avoid tox and run [pytest] directly, that is possible
 too.  You will need to run MongoDB and RabbitMQ, which can be launched
 with Docker:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,15 @@ repository:
 
 ## Running the test suite
 
-Some of the tests expects MongoDB and RabbitMQ, which can be launched
+You will need [tox] and [tox-docker]:
+
+```console
+$ pip install tox tox-docker
+$ tox
+```
+
+If you want to avoid tox and run [pytest] directly, that is possible
+too.  You will need to run MongoDB and RabbitMQ, which can be launched
 with Docker:
 
 ```console
@@ -175,19 +183,18 @@ edit it according to your environment, and make sure the env vars are
 present in your shell:
 
 ```console
+$ cp env.template .env 
+$ # and then edit .env to suit your environment
 $ source .env
-```
-
-And now run [tox]:
-
-```console
-$ tox
+$ pytest
 ```
 
 
 <!-- References -->
 
 [tox]: https://tox.wiki/en/latest/
+[tox-docker]: https://tox-docker.readthedocs.io/
+[pytest]: https://docs.pytest.org/
 
 [sdx-to-lc-img]: https://user-images.githubusercontent.com/29924060/139588273-100a0bb2-14ba-496f-aedf-a122b9793325.jpg
 [lc-to-sdx-img]: https://user-images.githubusercontent.com/29924060/139588283-2ea32803-92e3-4812-9e8a-3d829549ae40.jpg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,12 @@ include = '\.py?$'
 profile = "black"
 src_paths = ["sdx_controller", "bapm_server"]
 
+[tool.pytest.ini_options]
+addopts = "--cov=sdx_controller --cov=bapm_server --cov-report html --cov-report term-missing"
+testpaths = [
+    "sdx_controller/test"
+]
+
 [tool.coverage.run]
 branch = true
 omit = [ "sdx_controller/test/*" ]

--- a/tox.ini
+++ b/tox.ini
@@ -16,14 +16,16 @@ setenv =
     SDX_PORT = 8080
     SDX_VERSION = 1.0.0
     SDX_NAME = sdx-controller-test
-    MQ_HOST = localhost
+    # Disabling MQ_HOST: We do not test with MQ yet.
+    # MQ_HOST = localhost
     SUB_QUEUE = sdx-controller-test-queue
     DB_NAME = sdx-controller-test-db
     DB_CONFIG_TABLE_NAME = sdx-controller-test-table
     MONGODB_CONNSTRING = mongodb://guest:guest@localhost:27017/
 
 docker =
-    rabbitmq
+    # Disabling rabbitmq for now, until we write some tests.
+    # rabbitmq
     mongo
 
 [docker:rabbitmq]

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,23 @@ passenv =
     PUB_*
     DB_*
     MONGODB_CONNSTRING
+
+docker =
+    rabbitmq
+    mongo
+
+[docker:rabbitmq]
+image = rabbitmq:latest
+
+ports =
+    5672:5672/tcp
+
+[docker:mongo]
+image = mongo:7.0.5
+
+ports =
+    27017:27017/tcp
+
+environment =
+    MONGO_INITDB_ROOT_USERNAME=guest
+    MONGO_INITDB_ROOT_PASSWORD=guest

--- a/tox.ini
+++ b/tox.ini
@@ -11,13 +11,16 @@ deps =
 commands =
     pytest --cov sdx_controller --cov bapm_server {posargs}
 
-passenv =
-    SDX_*
-    MQ_*
-    SUB_*
-    PUB_*
-    DB_*
-    MONGODB_CONNSTRING
+setenv =
+    SDX_HOST = localhost
+    SDX_PORT = 8080
+    SDX_VERSION = 1.0.0
+    SDX_NAME = sdx-controller-test
+    MQ_HOST = localhost
+    SUB_QUEUE = sdx-controller-test-queue
+    DB_NAME = sdx-controller-test-db
+    DB_CONFIG_TABLE_NAME = sdx-controller-test-table
+    MONGODB_CONNSTRING = mongodb://guest:guest@localhost:27017/
 
 docker =
     rabbitmq


### PR DESCRIPTION
Resolves #241. Changes:

- Use tox-docker to spin up/down MongoDB and RabbitMQ services when testing with tox.  This is a little more convenient than having to do some manual setup before testing locally.
- README updates to reflect the above.
- CI updates to reflect the above.  On CI, we will run pytest instead of tox, so that reported coverage does not drop.  (Reason  is this: some MQ code gets exercised when running pytest, although we do not have tests that use MQ directly.  When running `tox` though, `MQ_HOST` is unset, and that will cause that part of code to not get invoked at all.  I'm planning to add some tests that use MQ, so this is a temporary workaround.)