### PR TITLE
Enable RabbitMQ when testing with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,16 +16,14 @@ setenv =
     SDX_PORT = 8080
     SDX_VERSION = 1.0.0
     SDX_NAME = sdx-controller-test
-    # Disabling MQ_HOST: We do not test with MQ yet.
-    # MQ_HOST = localhost
+    MQ_HOST = localhost
     SUB_QUEUE = sdx-controller-test-queue
     DB_NAME = sdx-controller-test-db
     DB_CONFIG_TABLE_NAME = sdx-controller-test-table
     MONGODB_CONNSTRING = mongodb://guest:guest@localhost:27017/
 
 docker =
-    # Disabling rabbitmq for now, until we write some tests.
-    # rabbitmq
+    rabbitmq
     mongo
 
 [docker:rabbitmq]

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,11 @@ image = rabbitmq:latest
 ports =
     5672:5672/tcp
 
+healthcheck_cmd = rabbitmq-diagnostics -q ping
+healthcheck_interval = 30
+healthcheck_timeout = 30
+healthcheck_retries = 3
+
 [docker:mongo]
 image = mongo:7.0.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,6 @@ ports =
     5672:5672/tcp
 
 healthcheck_cmd = rabbitmq-diagnostics -q ping
-healthcheck_interval = 30
-healthcheck_timeout = 30
-healthcheck_retries = 3
 
 [docker:mongo]
 image = mongo:7.0.5

--- a/tox.ini
+++ b/tox.ini
@@ -46,3 +46,5 @@ ports =
 environment =
     MONGO_INITDB_ROOT_USERNAME=guest
     MONGO_INITDB_ROOT_PASSWORD=guest
+
+healthcheck_cmd = mongosh localhost:27017/test --quiet


### PR DESCRIPTION
Resolves #244.  

There were errors when running `tox` with RabbitMQ enabled via tox-docker.  It turned out that we actually need to wait for RabbitMQ to be ready, which can be done by adding some health checks.