### PR TITLE
Fix pika auth for rpc_queue_consumer

### DIFF
--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -48,7 +48,13 @@ class RpcConsumer(object):
         self._thread_queue.put(message_body)
 
         self.connection = pika.BlockingConnection(
-            pika.ConnectionParameters(host=MQ_HOST)
+            pika.ConnectionParameters(
+                host=MQ_HOST,
+                port=MQ_PORT,
+                credentials=pika.PlainCredentials(
+                    username=MQ_USER, password=MQ_PASS
+                ),
+            )
         )
         self.channel = self.connection.channel()
 

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -51,9 +51,7 @@ class RpcConsumer(object):
             pika.ConnectionParameters(
                 host=MQ_HOST,
                 port=MQ_PORT,
-                credentials=pika.PlainCredentials(
-                    username=MQ_USER, password=MQ_PASS
-                ),
+                credentials=pika.PlainCredentials(username=MQ_USER, password=MQ_PASS),
             )
         )
         self.channel = self.connection.channel()


### PR DESCRIPTION
Fixes #253

We missed that change above, which ultimately results on the following error when running the full integration.