### PR TITLE
Use request connection id when saving to db

### DIFF
--- a/sdx_controller/controllers/connection_controller.py
+++ b/sdx_controller/controllers/connection_controller.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import uuid
 
 import connexion
 from flask import current_app
@@ -57,12 +58,16 @@ def place_connection(body):
     :rtype: Connection
     """
     logger.info(f"Placing connection: {body}")
-    if connexion.request.is_json:
-        body = connexion.request.get_json()
-        logger.info(f"Gathered connexion JSON: {body}")
+    if not connexion.request.is_json:
+        return "Request body must be JSON", 400
+
+    body = connexion.request.get_json()
+    logger.info(f"Gathered connexion JSON: {body}")
 
     logger.info("Placing connection. Saving to database.")
-    db_instance.add_key_value_pair_to_db("connection_data", json.dumps(body))
+    db_instance.add_key_value_pair_to_db(
+        body["id"] if "id" in body else str(uuid.uuid4()), json.dumps(body)
+    )
     logger.info("Saving to database complete.")
 
     logger.info(f"Handling request with te_manager: {current_app.te_manager}")

--- a/sdx_controller/controllers/connection_controller.py
+++ b/sdx_controller/controllers/connection_controller.py
@@ -65,9 +65,14 @@ def place_connection(body):
     logger.info(f"Gathered connexion JSON: {body}")
 
     logger.info("Placing connection. Saving to database.")
-    db_instance.add_key_value_pair_to_db(
-        body["id"] if "id" in body else str(uuid.uuid4()), json.dumps(body)
-    )
+
+    if "id" in body:
+        connection_id = body["id"]
+    else:
+        connection_id = uuid.uuid4()
+        body["id"] = connection_id
+
+    db_instance.add_key_value_pair_to_db(connection_id, json.dumps(body))
     logger.info("Saving to database complete.")
 
     logger.info(f"Handling request with te_manager: {current_app.te_manager}")

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -103,7 +103,7 @@ class ConnectionHandler:
 
         graph = te_manager.generate_graph_te()
         if graph is None:
-            return "Could not generate a graph", 200
+            return "Could not generate a graph", 500
 
         traffic_matrix = te_manager.generate_traffic_matrix(
             connection_request=connection_request

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -103,7 +103,7 @@ class ConnectionHandler:
 
         graph = te_manager.generate_graph_te()
         if graph is None:
-            return "Could not generate a graph", 400
+            return "Could not generate a graph", 200
 
         traffic_matrix = te_manager.generate_traffic_matrix(
             connection_request=connection_request


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/256

Use connection ID instead of hard coded db key name.

Also if we cannot generate a graph, it should not be 400, because it's not due to bad request. Would 500 make sense? 