### PR TITLE
Require connection_id from client to be uuid

### DIFF
--- a/sdx_controller/controllers/connection_controller.py
+++ b/sdx_controller/controllers/connection_controller.py
@@ -3,6 +3,7 @@ import logging
 
 import connexion
 from flask import current_app
+from uuid import UUID
 
 from sdx_controller.handlers.connection_handler import ConnectionHandler
 from sdx_controller.utils.db_utils import DbUtils
@@ -19,6 +20,29 @@ logger.setLevel(logging.DEBUG)
 db_instance = DbUtils()
 db_instance.initialize_db()
 connection_handler = ConnectionHandler(db_instance)
+
+
+def _is_valid_uuid(uuid_to_test, version=4):
+    """
+    Check if uuid_to_test is a valid UUID.
+
+     Returns
+    -------
+    `True` if uuid_to_test is a valid UUID, otherwise `False`.
+
+     Examples
+    --------
+    $ is_valid_uuid('c9bf9e57-1685-4c89-bafb-ff5af830be8a')
+    True
+    $ is_valid_uuid('c9bf9e58')
+    False
+    """
+
+    try:
+        uuid_obj = UUID(uuid_to_test, version=version)
+    except ValueError:
+        return False
+    return str(uuid_obj) == uuid_to_test
 
 
 def delete_connection(connection_id):
@@ -91,6 +115,9 @@ def place_connection(body):
     logger.info("Placing connection. Saving to database.")
 
     connection_id = body["id"]
+
+    if not _is_valid_uuid(connection_id):
+        return "connection_id must be UUID", 400
 
     db_instance.add_key_value_pair_to_db(connection_id, json.dumps(body))
     logger.info("Saving to database complete.")

--- a/sdx_controller/controllers/connection_controller.py
+++ b/sdx_controller/controllers/connection_controller.py
@@ -1,9 +1,9 @@
 import json
 import logging
+from uuid import UUID
 
 import connexion
 from flask import current_app
-from uuid import UUID
 
 from sdx_controller.handlers.connection_handler import ConnectionHandler
 from sdx_controller.utils.db_utils import DbUtils

--- a/sdx_controller/test/test_connection_controller.py
+++ b/sdx_controller/test/test_connection_controller.py
@@ -21,7 +21,7 @@ class TestConnectionController(BaseTestCase):
 
         Delete connection order by ID.
         """
-        connection_id = 2
+        connection_id = "285eea4b-1e86-4d54-bd75-f14b8cb4a63a"
         response = self.client.open(
             f"{BASE_PATH}/connection/{connection_id}",
             method="DELETE",
@@ -78,7 +78,7 @@ class TestConnectionController(BaseTestCase):
 
         Find connection by ID.
         """
-        connection_id = 10
+        connection_id = "285eea4b-1e86-4d54-bd75-f14b8cb4a63a"
         response = self.client.open(
             f"{BASE_PATH}/connection/{connection_id}",
             method="GET",
@@ -257,7 +257,7 @@ class TestConnectionController(BaseTestCase):
 
     def test_z100_getconnection_by_id_success(self):
         """Test case for getconnection_by_id existing connection."""
-        connection_id = "test-connection-request"
+        connection_id = "285eea4b-1e86-4d54-bd75-f14b8cb4a63a"
         response = self.client.open(
             f"{BASE_PATH}/connection/{connection_id}",
             method="GET",


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/216

This will require the "connection_id" from client "POST connection" to be UUID. We don't want the server to generate connection_id for client, because if the HTTP request from server to client is lost, client will not know the connection_id anymore.