### PR TITLE
use the new tagged pce with the enhanced user port support in breakdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@2.0.6.dev3",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@2.0.6.rc0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
(This was not a bug as the previous version will always, not sometimes, generate the breakdowns starting and ending with the OXP port, even the request has user port in it. The previous assumption is that user ports, esp. the vlan resource is not managed by sdx-controller.)

This enhancement extended the scope to include the user ports in breakdown. 

It comes with unittests to cover this user case that include (1) intra-oxp request and (2) cross-oxp request with mixed (1) user port and (2) OXP port

TBD: Currently the user port is assumed to have the full vlan range and in the vlan assignment procedure, it is given the vlan picked from the corresponding OXP port. This policy can be changed if OXPs want to