### PR TITLE
Add a test for `GET /connection/:connection_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ present in your shell:
 $ cp env.template .env 
 $ # and then edit .env to suit your environment
 $ source .env
-$ pytest```console
+$ pytest
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ repository:
 
 ## Running the test suite
 
-### With tox and tox-docker
+### With tox
 
 You will need [tox] and [tox-docker]:
 

--- a/README.md
+++ b/README.md
@@ -161,16 +161,33 @@ repository:
 
 ## Running the test suite
 
+### With tox and tox-docker
+
 You will need [tox] and [tox-docker]:
 
 ```console
+$ python3 -m venv venv --upgrade-deps
+$ source ./venv/bin/activate
 $ pip install tox tox-docker
+```
+
+Once you have `tox` and `tox-docker` installed, you can run tests:
+
+```console
 $ tox
 ```
 
+You can also run a single test:
+
+```console
+$ tox -- -s sdx_controller/test/test_connection_controller.py::TestConnectionController::test_getconnection_by_id
+```
+
 If you want to examine Docker logs after the test suite has exited,
-you can run `tox --docker-dont-stop [mongo|rabbitmq]`, and then use
+run tests with `tox --docker-dont-stop [mongo|rabbitmq]`, and then use
 `docker logs <container-name>`.
+
+### With pytest
 
 If you want to avoid tox and run [pytest] directly, that is possible
 too.  You will need to run MongoDB and RabbitMQ, which can be launched
@@ -190,7 +207,7 @@ present in your shell:
 $ cp env.template .env 
 $ # and then edit .env to suit your environment
 $ source .env
-$ pytest
+$ pytest```console
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
     "randomize >= 0.13",
 ]
 lint = [
-    "black == 23.*",
+    "black == 24.*",
     "isort == 5.*",
 ]
 wsgi = [

--- a/sdx_controller/test/__init__.py
+++ b/sdx_controller/test/__init__.py
@@ -20,9 +20,10 @@ class BaseTestCase(TestCase):
         # doesn't use a message queue right now.
         app = create_app(run_listener=True if os.getenv("MQ_HOST") else False)
 
-        # We need a handle to the TEManager instance in tests, but
-        # accessing it this way feels like a work-around. There must
-        # be a better way to get a handle to TEManager.
+        # TODO: We need a handle to the TEManager instance in tests,
+        # so we add a handle here, although doing it this way feels
+        # like a work-around.  There must be a better way to get a
+        # handle to TEManager?
         self.te_manager = app.te_manager
 
         return app.app

--- a/sdx_controller/test/test_connection_controller.py
+++ b/sdx_controller/test/test_connection_controller.py
@@ -268,6 +268,8 @@ class TestConnectionController(BaseTestCase):
             method="GET",
         )
 
+        print(f"Response body is : {response.data.decode('utf-8')}")
+
         self.assertStatus(response, 404)
 
     def test_z100_getconnection_by_id_expect_200(self):

--- a/sdx_controller/test/test_connection_controller.py
+++ b/sdx_controller/test/test_connection_controller.py
@@ -30,14 +30,10 @@ class TestConnectionController(BaseTestCase):
         )
         self.assert200(response, f"Response body is : {response.data.decode('utf-8')}")
 
-    def test_delete_connection_with_setup(self):
+    def __add_the_three_topologies(self):
         """
-        Test case for delete_connection()
-
-        Set up a connection request, get the connection ID from the
-        response, and then do `DELETE /connection/:connection_id`
+        A helper to add the three known topologies.
         """
-        # set up temanager connection first
         for idx, topology_file in enumerate(
             [
                 TestData.TOPOLOGY_FILE_AMLIGHT,
@@ -47,6 +43,16 @@ class TestConnectionController(BaseTestCase):
         ):
             topology = json.loads(topology_file.read_text())
             self.te_manager.add_topology(topology)
+
+    def test_delete_connection_with_setup(self):
+        """
+        Test case for delete_connection()
+
+        Set up a connection request, get the connection ID from the
+        response, and then do `DELETE /connection/:connection_id`
+        """
+        # set up temanager connection first
+        self.__add_the_three_topologies()
 
         request_body = TestData.CONNECTION_REQ.read_text()
 
@@ -196,13 +202,7 @@ class TestConnectionController(BaseTestCase):
 
         Place a connection request when some topologies are known.
         """
-        for topology_file in [
-            TestData.TOPOLOGY_FILE_AMLIGHT,
-            TestData.TOPOLOGY_FILE_SAX,
-            TestData.TOPOLOGY_FILE_ZAOXI,
-        ]:
-            topology = json.loads(topology_file.read_text())
-            self.te_manager.add_topology(topology)
+        self.__add_the_three_topologies()
 
         request = TestData.CONNECTION_REQ.read_text()
 

--- a/sdx_controller/test/test_connection_controller.py
+++ b/sdx_controller/test/test_connection_controller.py
@@ -269,6 +269,39 @@ class TestConnectionController(BaseTestCase):
         )
         self.assertStatus(response, 404)
 
+    def test_z100_getconnection_by_id_expect_200(self):
+        """
+        Test getconnection_by_id with a non-existent connection ID.
+        """
+
+        self.__add_the_three_topologies()
+
+        request_body = TestData.CONNECTION_REQ.read_text()
+
+        post_response = self.client.open(
+            f"{BASE_PATH}/connection",
+            method="POST",
+            data=request_body,
+            content_type="application/json",
+        )
+
+        print(f"Response body: {post_response.data.decode('utf-8')}")
+
+        self.assertStatus(post_response, 200)
+
+        connection_id = post_response.get_json().get("connection_id")
+        print(f"Got connection_id: {connection_id}")
+
+        # Now try `GET /connection/{connection_id}`
+        get_response = self.client.open(
+            f"{BASE_PATH}/connection/{connection_id}",
+            method="GET",
+        )
+
+        print(f"Response body: {get_response.data.decode('utf-8')}")
+
+        self.assertStatus(get_response, 200)
+
     @patch("sdx_controller.utils.db_utils.DbUtils.get_all_entries_in_collection")
     def test_z105_getconnections_fail(self, mock_get_all_entries):
         """Test case for getconnections."""

--- a/sdx_controller/test/test_connection_controller.py
+++ b/sdx_controller/test/test_connection_controller.py
@@ -261,6 +261,7 @@ class TestConnectionController(BaseTestCase):
         """
         Test getconnection_by_id with a non-existent connection ID.
         """
+        # Generate a random ID.
         connection_id = uuid.uuid4()
         response = self.client.open(
             f"{BASE_PATH}/connection/{connection_id}",

--- a/sdx_controller/test/test_connection_controller.py
+++ b/sdx_controller/test/test_connection_controller.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import unittest
+import uuid
 from unittest.mock import patch
 
 from flask import json
@@ -256,14 +257,16 @@ class TestConnectionController(BaseTestCase):
                 # up with all the expected topology data.
                 self.assertStatus(response, 200)
 
-    def test_z100_getconnection_by_id_success(self):
-        """Test case for getconnection_by_id existing connection."""
-        connection_id = "test-connection-request"
+    def test_z100_getconnection_by_id_expect_404(self):
+        """
+        Test getconnection_by_id with a non-existent connection ID.
+        """
+        connection_id = uuid.uuid4()
         response = self.client.open(
             f"{BASE_PATH}/connection/{connection_id}",
             method="GET",
         )
-        self.assertStatus(response, 200)
+        self.assertStatus(response, 404)
 
     @patch("sdx_controller.utils.db_utils.DbUtils.get_all_entries_in_collection")
     def test_z105_getconnections_fail(self, mock_get_all_entries):


### PR DESCRIPTION
Resolves #270.  Changes:

- Add a test case with topology and connection setup.  In this test we can expect a 200 response when doing a `GET /connection/:connection_id`.
- Update testing instructions in README.
- Bump up black version in `pyproject.toml` to be the same as CI.

Although #270 is assigned to @italovalcy, I made an attempt at it. ;-)