### PR TITLE
Add connection deletion

### DIFF
--- a/sdx_controller/controllers/connection_controller.py
+++ b/sdx_controller/controllers/connection_controller.py
@@ -50,6 +50,9 @@ def delete_connection(connection_id):
         #
         # https://github.com/atlanticwave-sdx/pce/issues/180
         current_app.te_manager.unreserve_vlan(connection_id)
+        deleted = db_instance.mark_deleted("connections", f"{connection_id}")
+        if not deleted:
+            return "Did not find connection", 404
     except Exception as e:
         logger.info(f"Delete failed (connection id: {connection_id}): {e}")
         return "Failed, reason: {e}", 500

--- a/sdx_controller/test/test_connection_controller.py
+++ b/sdx_controller/test/test_connection_controller.py
@@ -28,7 +28,7 @@ class TestConnectionController(BaseTestCase):
             f"{BASE_PATH}/connection/{connection_id}",
             method="DELETE",
         )
-        self.assert200(response, f"Response body is : {response.data.decode('utf-8')}")
+        self.assert404(response, f"Response body is : {response.data.decode('utf-8')}")
 
     def __add_the_three_topologies(self):
         """

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -53,7 +53,9 @@ class DbUtils(object):
 
     def read_from_db(self, collection, key):
         key = str(key)
-        return self.sdxdb[collection].find_one({key: {"$exists": 1}, "deleted": {"$ne": True}})
+        return self.sdxdb[collection].find_one(
+            {key: {"$exists": 1}, "deleted": {"$ne": True}}
+        )
 
     def get_all_entries_in_collection(self, collection):
         db_collection = self.sdxdb[collection]

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -45,20 +45,29 @@ class DbUtils(object):
         key = str(key)
         obj = self.read_from_db(collection, key)
         if obj is None:
-            # self.logger.debug(f"Adding key value pair {key}:{value} to DB.")
             return self.sdxdb[collection].insert_one({key: value})
 
         query = {"_id": obj["_id"]}
-        # self.logger.debug(f"Updating DB entry {key}:{value}.")
         result = self.sdxdb[collection].replace_one(query, {key: value})
         return result
 
     def read_from_db(self, collection, key):
         key = str(key)
-        return self.sdxdb[collection].find_one({key: {"$exists": 1}})
+        return self.sdxdb[collection].find_one({key: {"$exists": 1}, "deleted": {"$ne": True}})
 
     def get_all_entries_in_collection(self, collection):
         db_collection = self.sdxdb[collection]
         # MongoDB has an ObjectId for each item, so need to exclude the ObjectIds
         all_entries = db_collection.find({}, {"_id": 0})
         return all_entries
+
+    def mark_deleted(self, collection, key):
+        db_collection = self.sdxdb[collection]
+        key = str(key)
+        item_to_delete = self.read_from_db(collection, key)
+        if item_to_delete is None:
+            return False
+        filter = {"_id": item_to_delete["_id"]}
+        update = {"$set": {"deleted": True}}
+        db_collection.update_one(filter, update)
+        return True

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ setenv =
     SDX_VERSION = 1.0.0
     SDX_NAME = sdx-controller-test
     MQ_HOST = localhost
+    MQ_PORT = 5672
     SUB_QUEUE = sdx-controller-test-queue
     DB_NAME = sdx-controller-test-db
     DB_CONFIG_TABLE_NAME = sdx-controller-test-table


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/266

Add a database function to mark object as deleted. Then add a delete function for DELETE connection API.
```
"DELETE /SDX-Controller/1.0.0/connection/285eea4b-1e86-4d54-bd75-f14b8cb4a63a HTTP/1.1" 200 OK
"DELETE /SDX-Controller/1.0.0/connection/285eea4b-1e86-4d54-bd75-f14b8cb4a63a HTTP/1.1" 404 Not Found
"GET /SDX-Controller/1.0.0/connection/285eea4b-1e86-4d54-bd75-f14b8cb4a63a HTTP/1.1" 404 Not Found
```