### PR TITLE
Exclude deleted connections when listing all connections

### DIFF
--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -60,7 +60,7 @@ class DbUtils(object):
     def get_all_entries_in_collection(self, collection):
         db_collection = self.sdxdb[collection]
         # MongoDB has an ObjectId for each item, so need to exclude the ObjectIds
-        all_entries = db_collection.find({}, {"_id": 0})
+        all_entries = db_collection.find({"deleted": {"$ne": True}}, {"_id": 0})
         return all_entries
 
     def mark_deleted(self, collection, key):


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/266

This will exclude the deleted connection when calling GET connections API.