### PR TITLE
CI housekeeping: use the right coveralls client to finalize

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,11 +103,9 @@ jobs:
     name: finalize
     needs: test
     runs-on: ubuntu-latest
-    container: python:3-slim
+    if: ${{ always() }}
     steps:
       - name: Indicate completion to coveralls.io
-        run: |
-          pip --no-cache-dir install --upgrade coveralls
-          python -m coveralls --service=github --finish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ wsgi = [
     "uvicorn"
 ]
 
-[options.packages.find]
-where = "swagger_server"
-
 [tool.setuptools]
 packages = ["sdx_controller", "bapm_server"]
 


### PR DESCRIPTION
We have been using coverallsapp/github-action to send test coverage to coveralls.io, and Python coveralls to indicate test completion.  This change switches to using coverallsapp/github-action for the latter also.

Also removes the stale options.packages.find hint from `pyproject.toml`.
