### PR TITLE
Use MongoDB 7.0.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - 15672:15672
 
       mongodb:
-        image: mongo:7.0.5
+        image: mongo:7.0.11
         ports:
           - 27017:27017
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,6 @@ jobs:
         env:
           SDX_HOST: 'localhost'
           SDX_PORT: '8080'
-          SDX_VERSION: '1.0.0'
           SDX_NAME: 'sdx-controller-test'
           MQ_HOST: 'localhost'
           MQ_PORT: '5672'

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ with Docker:
 
 ```console
 $ docker run --rm -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:latest
-$ docker run --rm -d --name mongo -p 27017:27017 -e MONGO_INITDB_ROOT_USERNAME=guest -e MONGO_INITDB_ROOT_PASSWORD=guest mongo:7.0.5
+$ docker run --rm -d --name mongo -p 27017:27017 -e MONGO_INITDB_ROOT_USERNAME=guest -e MONGO_INITDB_ROOT_PASSWORD=guest mongo:7.0.11
 ```
 
 Some environment variables are expected to be set for the tests to

--- a/compose.yml
+++ b/compose.yml
@@ -43,7 +43,6 @@ services:
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
       - SDX_HOST=${SDX_HOST}
       - SDX_PORT=${SDX_PORT}
-      - SDX_VERSION=${SDX_VERSION}
       - MQ_HOST=${MQ_HOST}
       - SUB_QUEUE=${SUB_QUEUE}
       - DB_NAME=${DB_NAME}

--- a/compose.yml
+++ b/compose.yml
@@ -6,8 +6,8 @@ services:
     # See https://hub.docker.com/_/mongo/ for documentation about
     # MongoDB Docker images.
     image: mongo:7.0.11
-    ports:
-      - ${MONGO_PORT}:${MONGO_PORT}
+    expose:
+      - ${MONGO_PORT}
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}

--- a/compose.yml
+++ b/compose.yml
@@ -28,7 +28,7 @@ services:
     image: sdx-controller
     depends_on:
       mongodb:
-        # Anther condition is `service_healthy`, and it will require
+        # Another condition is `service_healthy`, and it will require
         # the `healthcheck` above.
         condition: service_started
     tty: true

--- a/compose.yml
+++ b/compose.yml
@@ -5,7 +5,7 @@ services:
   mongodb:
     # See https://hub.docker.com/_/mongo/ for documentation about
     # MongoDB Docker images.
-    image: mongo:7.0.5
+    image: mongo:7.0.11
     ports:
       - ${MONGO_PORT}:${MONGO_PORT}
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -40,6 +40,7 @@ services:
       # the same MONGODB_CONNSTRING variable from .env here, because
       # that is helpful for running unit/integration tests.
       - MONGODB_CONNSTRING=mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongodb:${MONGO_PORT}/
+      - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
       - SDX_HOST=${SDX_HOST}
       - SDX_PORT=${SDX_PORT}
       - SDX_VERSION=${SDX_VERSION}

--- a/env.template
+++ b/env.template
@@ -2,7 +2,6 @@
 # SDX Controller settings.
 export SDX_HOST="localhost"
 export SDX_PORT="8080"
-export SDX_VERSION="1.0.0"
 export SDX_NAME="sdx-controller-test"
 
 # Message queue settings for SDX Controller.

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ ports =
 healthcheck_cmd = rabbitmq-diagnostics -q ping
 
 [docker:mongo]
-image = mongo:7.0.5
+image = mongo:7.0.11
 
 ports =
     27017:27017/tcp

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ commands =
 setenv =
     SDX_HOST = localhost
     SDX_PORT = 8080
-    SDX_VERSION = 1.0.0
     SDX_NAME = sdx-controller-test
     MQ_HOST = localhost
     MQ_PORT = 5672


### PR DESCRIPTION
Resolves #276.  Changes:

- Use MongoDB 7.0.11.
- Expose `$MONGO_PORT` only to linked services, not to the world outside.
- Pass missing `$DB_CONFIG_TABLE_NAME`.
- Remove unused `$SDX_VERSION`.
- Ignore all `.env*` files.
