### PR TITLE
Multi-stage Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+# We specify a multi-stage build here.  Some of the packages we use
+# need a compiler to install, but not at runtime.  Using a multi-stage
+# build results in smaller final images, since we won't be install
+# things we don't need in them.
+
+# The builder image.
 FROM python:3.9-slim-bullseye AS sdx-builder-image
 
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.9-slim-bullseye AS sdx-builder-image
 
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -17,6 +17,12 @@ COPY . /usr/src/app
 # https://github.com/pypa/setuptools_scm/issues/77#issuecomment-844927695
 RUN --mount=source=.git,target=.git,type=bind \
     pip install --no-cache-dir .[wsgi]
+
+# The final image.
+FROM python:3.9-slim-bullseye AS sdx-runtime-image
+
+WORKDIR /usr/src/app
+COPY --from=sdx-builder-image /usr/src/app /usr/src/app
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ RUN apt-get update \
 
 WORKDIR /usr/src/app
 
+# create a venv.
+RUN python -m venv /opt/venv --upgrade-deps
+
+# Make sure we use the venv.
+ENV PATH="/opt/venv/bin:$PATH"
+
 COPY . /usr/src/app
 
 # In order to make setuptools_scm work during container build, we
@@ -21,7 +27,10 @@ RUN --mount=source=.git,target=.git,type=bind \
 FROM python:3.9-slim-bullseye AS sdx-runtime-image
 
 WORKDIR /usr/src/app
-COPY --from=sdx-builder-image /usr/src/app /usr/src/app
+COPY --from=sdx-builder-image /opt/venv /opt/venv
+
+# Make sure we use the venv.
+ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN --mount=source=.git,target=.git,type=bind \
 # The final image.
 FROM python:3.9-slim-bullseye AS sdx-runtime-image
 
-WORKDIR /usr/src/app
 COPY --from=sdx-builder-image /opt/venv /opt/venv
 
 # Make sure we use the venv.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
 
 WORKDIR /usr/src/app
 
-WORKDIR /usr/src/app
 COPY . /usr/src/app
 
 # In order to make setuptools_scm work during container build, we


### PR DESCRIPTION
Resolves #176.  The final image should be a few hundreds of MB smaller than what we currently have.
