### PR TITLE
Remove obsolete `version` field from compose spec

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
 
   mongodb:


### PR DESCRIPTION
Resolves #278.
