### PR TITLE
Use tox-docker `expose` directive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,13 @@ jobs:
           MQ_USER: 'guest'
           MQ_PASS: 'guest'
           SUB_QUEUE: 'sdx-controller-test-queue'
+          MONGO_HOST: 'localhost'
+          MONGO_PORT: '27017'
+          MONGO_USER: 'guest'
+          MONGO_PASS: 'guest'
           DB_NAME: 'sdx-controllder-test-db'
           DB_CONFIG_TABLE_NAME: 'sdx-controller-test-table'
-          MONGODB_CONNSTRING: 'mongodb://guest:guest@localhost:27017/'
+
         timeout-minutes: 3
 
       - name: Send coverage data to coveralls.io

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ repository:
 
 ### With tox
 
-You will need [tox] and [tox-docker]:
+You will need Docker installed and running. You will also need [tox]
+and [tox-docker]:
 
 ```console
 $ python3 -m venv venv --upgrade-deps
@@ -190,8 +191,7 @@ run tests with `tox --docker-dont-stop [mongo|rabbitmq]`, and then use
 ### With pytest
 
 If you want to avoid tox and run [pytest] directly, that is possible
-too.  You will need to run MongoDB and RabbitMQ, which can be launched
-with Docker:
+too.  You will need to run RabbitMQ and MongoDB, with Docker perhaps:
 
 ```console
 $ docker run --rm -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:latest

--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ present in your shell:
 $ cp env.template .env 
 $ # and then edit .env to suit your environment
 $ source .env
+```
+
+And now, activate a virtual environment, install the requirements, and
+then run `pytest`:
+
+```
+$ python3 -m venv venv --upgrade-deps
+$ source ./venv/bin/activate
+$ pip3 install --editable .[test]
 $ pytest
 ```
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ You will need [tox] and [tox-docker]:
 ```console
 $ python3 -m venv venv --upgrade-deps
 $ source ./venv/bin/activate
-$ pip install tox tox-docker
+$ pip install 'tox>=4' 'tox-docker>=5'
 ```
 
 Once you have `tox` and `tox-docker` installed, you can run tests:

--- a/README.md
+++ b/README.md
@@ -178,10 +178,11 @@ Once you have `tox` and `tox-docker` installed, you can run tests:
 $ tox
 ```
 
-You can also run a single test:
+You can also run a single test, and optionally, print logs on the
+console:
 
 ```console
-$ tox -- -s sdx_controller/test/test_connection_controller.py::TestConnectionController::test_getconnection_by_id
+$ tox -- -s --log-cli-level=INFO sdx_controller/test/test_connection_controller.py::TestConnectionController::test_getconnection_by_id
 ```
 
 If you want to examine Docker logs after the test suite has exited,

--- a/compose.bapm.yml
+++ b/compose.bapm.yml
@@ -6,8 +6,8 @@ services:
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
     # for a more elaborate setup.
     image: elasticsearch:8.11.3
-    ports:
-      - ${ES_PORT}:${ES_PORT}
+    expose:
+      - ${ES_PORT}
     environment:
       - xpack.security.enabled=false
       - discovery.type=single-node

--- a/compose.bapm.yml
+++ b/compose.bapm.yml
@@ -31,7 +31,8 @@ services:
     tty: true
     build: ./bapm_server
     environment:
-      - ES_HOST=${ES_HOST}
+      # Connect to the elasticsearch service above.
+      - ES_HOST=elasticsearch
       - ES_PORT=${ES_PORT}
       - BAPM_MQ_HOST=${BAPM_MQ_HOST}
       - BAPM_EXCHANGE=${BAPM_EXCHANGE}

--- a/compose.yml
+++ b/compose.yml
@@ -48,10 +48,11 @@ services:
       - MONGO_PORT=${MONGO_PORT:-27017}
       - MONGO_USER=${MONGO_USER:-"guest"}
       - MONGO_PASS=${MONGO_PASS:-"guest"}
+      - DB_NAME=${DB_NAME}      
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
       - MQ_HOST=${MQ_HOST}
       - SUB_QUEUE=${SUB_QUEUE}
-      - DB_NAME=${DB_NAME}
+
 
 volumes:
   mongodb:

--- a/compose.yml
+++ b/compose.yml
@@ -7,8 +7,8 @@ services:
     expose:
       - ${MONGO_PORT}
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-"guest"}
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-"guest"}
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-guest}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-guest}
     volumes:
       # See https://docs.docker.com/storage/volumes/
       #
@@ -41,13 +41,13 @@ services:
       - 8080:8080
     environment:
       # App settings.
-      - SDX_HOST=${SDX_HOST:-"localhost"}
+      - SDX_HOST=${SDX_HOST:-localhost}
       - SDX_PORT=${SDX_PORT:-8080}
       # Use mongodb service specified above.
-      - MONGO_HOST="mongodb"
+      - MONGO_HOST=mongodb
       - MONGO_PORT=${MONGO_PORT:-27017}
-      - MONGO_USER=${MONGO_USER:-"guest"}
-      - MONGO_PASS=${MONGO_PASS:-"guest"}
+      - MONGO_USER=${MONGO_USER:-guest}
+      - MONGO_PASS=${MONGO_PASS:-guest}
       - DB_NAME=${DB_NAME}
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
       # MQ settings

--- a/compose.yml
+++ b/compose.yml
@@ -40,14 +40,15 @@ services:
     ports:
       - 8080:8080
     environment:
+      # App settings.
+      - SDX_HOST=${SDX_HOST:-"localhost"}
+      - SDX_PORT=${SDX_PORT:-8080}
       # Use mongodb service specified above.
       - MONGO_HOST="mongodb"
       - MONGO_PORT=${MONGO_PORT:-27017}
       - MONGO_USER=${MONGO_USER:-"guest"}
       - MONGO_PASS=${MONGO_PASS:-"guest"}
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
-      - SDX_HOST=${SDX_HOST}
-      - SDX_PORT=${SDX_PORT}
       - MQ_HOST=${MQ_HOST}
       - SUB_QUEUE=${SUB_QUEUE}
       - DB_NAME=${DB_NAME}

--- a/compose.yml
+++ b/compose.yml
@@ -7,8 +7,8 @@ services:
     expose:
       - ${MONGO_PORT}
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-"guest"}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-"guest"}
     volumes:
       # See https://docs.docker.com/storage/volumes/
       #

--- a/compose.yml
+++ b/compose.yml
@@ -48,11 +48,12 @@ services:
       - MONGO_PORT=${MONGO_PORT:-27017}
       - MONGO_USER=${MONGO_USER:-"guest"}
       - MONGO_PASS=${MONGO_PASS:-"guest"}
-      - DB_NAME=${DB_NAME}      
+      - DB_NAME=${DB_NAME}
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
+      # MQ settings
       - MQ_HOST=${MQ_HOST}
+      - MQ_PORT=${MQ_PORT:-5672}
       - SUB_QUEUE=${SUB_QUEUE}
-
 
 volumes:
   mongodb:

--- a/compose.yml
+++ b/compose.yml
@@ -40,10 +40,11 @@ services:
     ports:
       - 8080:8080
     environment:
-      # Use mongodb service specified above.  Note that we do not use
-      # the same MONGODB_CONNSTRING variable from .env here, because
-      # that is helpful for running unit/integration tests.
-      - MONGODB_CONNSTRING=mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongodb:${MONGO_PORT}/
+      # Use mongodb service specified above.
+      - MONGO_HOST="mongodb"
+      - MONGO_PORT=${MONGO_PORT:-27017}
+      - MONGO_USER=${MONGO_USER:-"guest"}
+      - MONGO_PASS=${MONGO_PASS:-"guest"}
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
       - SDX_HOST=${SDX_HOST}
       - SDX_PORT=${SDX_PORT}

--- a/env.template
+++ b/env.template
@@ -20,7 +20,8 @@ export MONGO_INITDB_ROOT_PASSWORD="guest"
 # the compose file.
 export MONGO_HOST="localhost"
 export MONGO_PORT="27017"
-export MONGODB_CONNSTRING="mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/"
+export MONGO_USER="guest"
+export MONGO_PASS="guest"
 export MONGODB_DATA_DIR='/data/db'
 
 export DB_NAME="sdx-controllder-test-db"

--- a/env.template
+++ b/env.template
@@ -22,7 +22,6 @@ export MONGO_HOST="localhost"
 export MONGO_PORT="27017"
 export MONGO_USER="guest"
 export MONGO_PASS="guest"
-export MONGODB_DATA_DIR='/data/db'
 
 export DB_NAME="sdx-controllder-test-db"
 export DB_CONFIG_TABLE_NAME="sdx-controller-test-table"

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -25,6 +25,8 @@ class RpcConsumer(object):
     def __init__(self, thread_queue, exchange_name, te_manager):
         self.logger = logging.getLogger(__name__)
 
+        self.logger.info(f"[MQ] Using amqp://{MQ_USER}@{MQ_HOST}:{MQ_PORT}")
+
         self.connection = pika.BlockingConnection(
             pika.ConnectionParameters(
                 host=MQ_HOST,

--- a/sdx_controller/test/test_db_utils.py
+++ b/sdx_controller/test/test_db_utils.py
@@ -26,7 +26,11 @@ class DbUtilsTests(unittest.TestCase):
         # Set up the necessary environment variables.
         os.environ["DB_NAME"] = self.env.get("DB_NAME")
         os.environ["DB_CONFIG_TABLE_NAME"] = self.env.get("DB_CONFIG_TABLE_NAME")
-        os.environ["MONGODB_CONNSTRING"] = self.env.get("MONGODB_CONNSTRING")
+
+        os.environ["MONGO_HOST"] = self.env.get("MONGO_HOST")
+        os.environ["MONGO_PORT"] = self.env.get("MONGO_PORT")
+        os.environ["MONGO_USER"] = self.env.get("MONGO_USER")
+        os.environ["MONGO_PASS"] = self.env.get("MONGO_PASS")
 
         # This should not raise an exception.
         dbutils = DbUtils()
@@ -36,7 +40,11 @@ class DbUtilsTests(unittest.TestCase):
         # Set up the necessary environment variables.
         os.environ["DB_NAME"] = self.env.get("DB_NAME")
         os.environ["DB_CONFIG_TABLE_NAME"] = "topologies"
-        os.environ["MONGODB_CONNSTRING"] = self.env.get("MONGODB_CONNSTRING")
+
+        os.environ["MONGO_HOST"] = self.env.get("MONGO_HOST")
+        os.environ["MONGO_PORT"] = self.env.get("MONGO_PORT")
+        os.environ["MONGO_USER"] = self.env.get("MONGO_USER")
+        os.environ["MONGO_PASS"] = self.env.get("MONGO_PASS")
 
         dbutils = DbUtils()
         dbutils.initialize_db()

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -28,12 +28,19 @@ class DbUtils(object):
         if mongo_port is None:
             raise Exception("MONGO_PORT environment variable is not set")
 
-        mongo_connstring = f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"
-
-        self.mongo_client = pymongo.MongoClient(mongo_connstring)
-
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
+
+        mongo_connstring = (
+            f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"
+        )
+
+        # Log DB URI, without a password.
+        self.logger.info(
+            f"[DB] Using mongodb://{mongo_user}@{mongo_host}:{mongo_port}/"
+        )
+
+        self.mongo_client = pymongo.MongoClient(mongo_connstring)
 
     def initialize_db(self):
         self.logger.debug(f"Trying to load {self.db_name} from DB")

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -17,9 +17,19 @@ class DbUtils(object):
         # if self.config_table_name is None:
         #     raise Exception("DB_CONFIG_TABLE_NAME environ variable is not set")
 
-        mongo_connstring = os.environ.get("MONGODB_CONNSTRING")
-        if mongo_connstring is None:
-            raise Exception("MONGODB_CONNSTRING environment variable is not set")
+        mongo_user = os.getenv("MONGO_USER") or "guest"
+        mongo_pass = os.getenv("MONGO_PASS") or "guest"
+        mongo_host = os.getenv("MONGO_HOST")
+        mongo_port = os.getenv("MONGO_PORT")
+
+        if mongo_host is None:
+            raise Exception("MONGO_HOST environment variable is not set")
+
+        if mongo_port is None:
+            raise Exception("MONGO_PORT environment variable is not set")
+
+        mongo_connstring = f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"
+
         self.mongo_client = pymongo.MongoClient(mongo_connstring)
 
         self.logger = logging.getLogger(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,12 @@ requires =
 deps =
     [test]
 
+allowlist_externals = printenv
+
 commands =
+    # First print the env vars so we know what we're using.
+    printenv
+    # Then run the tests.
     pytest --cov sdx_controller --cov bapm_server {posargs}
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -29,16 +29,16 @@ docker =
 [docker:rabbitmq]
 image = rabbitmq:latest
 
-ports =
-    5672:5672/tcp
+expose =
+    MQ_PORT=5672/tcp
 
 healthcheck_cmd = rabbitmq-diagnostics -q ping
 
 [docker:mongo]
 image = mongo:7.0.11
 
-ports =
-    27017:27017/tcp
+expose =
+    MONGO_PORT=27017/tcp
 
 environment =
     MONGO_INITDB_ROOT_USERNAME=guest

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,12 @@ setenv =
     MQ_HOST = localhost
     MQ_PORT = 5672
     SUB_QUEUE = sdx-controller-test-queue
+    MONGO_USER = guest
+    MONGO_PASS = guest
+    MONGO_HOST = localhost
+    MONGO_PORT = 27017
     DB_NAME = sdx-controller-test-db
     DB_CONFIG_TABLE_NAME = sdx-controller-test-table
-    MONGODB_CONNSTRING = mongodb://guest:guest@localhost:27017/
 
 docker =
     rabbitmq


### PR DESCRIPTION
Resolves #291 by splitting `MONGODB_CONNSTRING` to `MONGO_HOST`, `MONGO_PORT`, `MONGO_USER`, and `MONGO_PASS`.

