### PR TITLE
Use MONGODB_CONNSTRING when MONGO_HOST is not set

### DIFF
--- a/env.template
+++ b/env.template
@@ -23,6 +23,12 @@ MONGO_PORT=27017
 MONGO_USER=guest
 MONGO_PASS=guest
 
+# # Alternative to specifying the above variables for accessing
+# # MongoDB, you can unset MONGO_HOST etc and use MONGODB_CONNSTRING
+# # instead. This appears to be useful when using a MongoDB replica
+# # set.  See https://github.com/atlanticwave-sdx/sdx-lc/issues/153.
+# MONGODB_CONNSTRING=mongodb://guest:guest@localhost:27017/
+
 DB_NAME=sdx-controllder-test-db
 DB_CONFIG_TABLE_NAME=sdx-controller-test-table
 

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -10,6 +10,7 @@ COLLECTION_NAMES = ["topologies", "connections", "breakdowns", "domains", "links
 pymongo_logger = logging.getLogger("pymongo")
 pymongo_logger.setLevel(logging.INFO)
 
+
 def obfuscate_password_in_uri(uri: str) -> str:
     """
     Replace password field in URIs with a `*`, for logging.
@@ -19,6 +20,7 @@ def obfuscate_password_in_uri(uri: str) -> str:
         return uri.replace(parts.password, "*")
     else:
         return uri
+
 
 class DbUtils(object):
     def __init__(self):

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from urllib.parse import urlparse
 
 import pymongo
 
@@ -9,6 +10,15 @@ COLLECTION_NAMES = ["topologies", "connections", "breakdowns", "domains", "links
 pymongo_logger = logging.getLogger("pymongo")
 pymongo_logger.setLevel(logging.INFO)
 
+def obfuscate_password_in_uri(uri: str) -> str:
+    """
+    Replace password field in URIs with a `*`, for logging.
+    """
+    parts = urlparse(uri)
+    if parts.password:
+        return uri.replace(parts.password, "*")
+    else:
+        return uri
 
 class DbUtils(object):
     def __init__(self):
@@ -23,25 +33,22 @@ class DbUtils(object):
         mongo_user = os.getenv("MONGO_USER") or "guest"
         mongo_pass = os.getenv("MONGO_PASS") or "guest"
         mongo_host = os.getenv("MONGO_HOST")
-        mongo_port = os.getenv("MONGO_PORT")
+        mongo_port = os.getenv("MONGO_PORT") or 27017
 
         if mongo_host is None:
-            raise Exception("MONGO_HOST environment variable is not set")
-
-        if mongo_port is None:
-            raise Exception("MONGO_PORT environment variable is not set")
+            mongo_connstring = os.getenv("MONGODB_CONNSTRING")
+            if mongo_connstring is None:
+                raise Exception("Neither MONGO_HOST nor MONGODB_CONNSTRING is set")
+        else:
+            mongo_connstring = (
+                f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"
+            )
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
 
-        mongo_connstring = (
-            f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"
-        )
-
         # Log DB URI, without a password.
-        self.logger.info(
-            f"[DB] Using mongodb://{mongo_user}@{mongo_host}:{mongo_port}/"
-        )
+        self.logger.info(f"[DB] Using {obfuscate_password_in_uri(mongo_connstring)}")
 
         self.mongo_client = pymongo.MongoClient(mongo_connstring)
 


### PR DESCRIPTION
Similar to https://github.com/atlanticwave-sdx/sdx-lc/pull/154 (Issue https://github.com/atlanticwave-sdx/sdx-lc/issues/153)

When MONGO_HOST is not set, try to use MONGODB_CONNSTRING (basically falls back to the old method of specifying the MongoDB URI), and fail when neither is set.