### PR TITLE
Also delete breakdown when deleting connection

### DIFF
--- a/bapm_server/__main__.py
+++ b/bapm_server/__main__.py
@@ -44,7 +44,7 @@ def start_consumer(thread_queue, es):
 
 
 def main():
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
 
     es = Elasticsearch([{"host": ES_HOST, "port": ES_PORT}])
 

--- a/sdx_controller/controllers/connection_controller.py
+++ b/sdx_controller/controllers/connection_controller.py
@@ -55,6 +55,7 @@ def delete_connection(connection_id):
             return "Did not find connection", 404
         connection_handler.remove_connection(current_app.te_manager, connection_id)
         db_instance.mark_deleted("connections", f"{connection_id}")
+        db_instance.mark_deleted("breakdowns", f"{connection_id}")
     except Exception as e:
         logger.info(f"Delete failed (connection id: {connection_id}): {e}")
         return f"Failed, reason: {e}", 500


### PR DESCRIPTION
Quick fix, when deleting connection, also delete breakdown from the db. Also use debug mode by default, so we can see more info from sdx instance.