### PR TITLE
Save connection request only when getting 200 code

### DIFF
--- a/sdx_controller/controllers/connection_controller.py
+++ b/sdx_controller/controllers/connection_controller.py
@@ -120,7 +120,6 @@ def place_connection(body):
         body["id"] = connection_id
         logger.info(f"Request has no ID. Generated ID: {connection_id}")
 
-    db_instance.add_key_value_pair_to_db("connections", connection_id, json.dumps(body))
     logger.info("Saving to database complete.")
 
     logger.info(
@@ -128,6 +127,10 @@ def place_connection(body):
     )
 
     reason, code = connection_handler.place_connection(current_app.te_manager, body)
+    
+    if code == 200:
+        db_instance.add_key_value_pair_to_db("connections", connection_id, json.dumps(body))
+
     logger.info(
         f"place_connection result: ID: {connection_id} reason='{reason}', code={code}"
     )

--- a/sdx_controller/controllers/connection_controller.py
+++ b/sdx_controller/controllers/connection_controller.py
@@ -127,9 +127,11 @@ def place_connection(body):
     )
 
     reason, code = connection_handler.place_connection(current_app.te_manager, body)
-    
+
     if code == 200:
-        db_instance.add_key_value_pair_to_db("connections", connection_id, json.dumps(body))
+        db_instance.add_key_value_pair_to_db(
+            "connections", connection_id, json.dumps(body)
+        )
 
     logger.info(
         f"place_connection result: ID: {connection_id} reason='{reason}', code={code}"


### PR DESCRIPTION
Currently SDX controller saves all connection requests, but failed connection request doesn't have breakdown, and cannot be deleted. This PR only saves connection request when getting 200 code.