### PR TITLE
Add traceback information when exception on breakdown

### DIFF
--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from typing import Tuple
+import traceback
 
 from sdx_pce.load_balancing.te_solver import TESolver
 from sdx_pce.topology.temanager import TEManager
@@ -126,7 +127,8 @@ class ConnectionHandler:
             logger.debug(f"Breakdown sent to LC, status: {status}, code: {code}")
             return status, code
         except Exception as e:
-            logger.debug(f"Error when generating/publishing breakdown: {e}")
+            err = traceback.format_exc().replace("\n", ", ")
+            logger.error(f"Error when generating/publishing breakdown: {e} - {err}")
             return f"Error: {e}", 400
 
     def remove_connection(self, te_manager, connection_id) -> Tuple[str, int]:

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -1,7 +1,7 @@
 import json
 import logging
-from typing import Tuple
 import traceback
+from typing import Tuple
 
 from sdx_pce.load_balancing.te_solver import TESolver
 from sdx_pce.topology.temanager import TEManager


### PR DESCRIPTION
Fix #305 

## Description of the change

This PR introduces a simple change to include logging information (traceback) when the breakdown connection is created.