### PR TITLE
Adjustment of the mandatory fields in the Topology data model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@2.0.6.rc2",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@main",
 ]
 
 [project.optional-dependencies]

--- a/sdx_controller/swagger/swagger.yaml
+++ b/sdx_controller/swagger/swagger.yaml
@@ -486,12 +486,8 @@ components:
         name: Connection
     connection_v2:
       required:
-      - description
       - endpoints
       - name
-      - notifications
-      - qos_metrics
-      - scheduling
       type: object
       properties:
         name:


### PR DESCRIPTION
Fix #302 

## Description of the change

- Unlist some fields from the mandatory properties for the topology (according to topology data model spec 2.0.0)
- Using datamodel version from main branch to leverage recent changes for the topo 2.0.0 adjustments.