### PR TITLE
Modify link failure handler to leverage topology update messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@fix/issue_controller_161",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@main",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@fix/issue_200",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@fix/issue_controller_161",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@main",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@fix/issue_200",
 ]
 
 [project.optional-dependencies]

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -40,9 +40,12 @@ class LcMessageHandler:
             logger.info("Updating topo")
             logger.debug(msg_json)
             self.te_manager.update_topology(msg_json)
-            if "link_failure" in msg_json:
+            failed_links = self.te_manager.get_failed_links()
+            if failed_links:
                 logger.info("Processing link failure.")
-                self.connection_handler.handle_link_failure(self.te_manager, msg_json)
+                self.connection_handler.handle_link_failure(
+                    self.te_manager, failed_links
+                )
         # Add new topology
         else:
             domain_list.append(domain_name)

--- a/sdx_controller/models/simple_link.py
+++ b/sdx_controller/models/simple_link.py
@@ -3,7 +3,7 @@ from typing import List
 
 class SimpleLink:
     def __init__(self, ports: List[str]):
-        self._ports = ports
+        self.ports = ports
 
     @property
     def ports(self) -> List[str]:


### PR DESCRIPTION
Fix #161 

Heads-Up: this PR depends on https://github.com/atlanticwave-sdx/pce/pull/206

### Description of the change

- Upon receiving a topology update message, get the failed links from PCE
- adding fixes to the existing link failure handler
- enhance the connections per link map mainly in two aspects: 1) consider inter-domain links (which are the most important aspect for link failure handler, once intra-OXP the OXPO is likely to handle the failure); 2) removing connections was not removing from the map correctly
- adding logging messages to help network operator troubleshoot eventual future issues