### PR TITLE
Reuse service id for patch

### DIFF
--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -53,6 +53,7 @@ def create_app(run_listener: bool = True):
     else:
         logging.basicConfig(level=logging.DEBUG)
 
+    logging.getLogger("sdx_pce.topology.temanager").setLevel(logging.INFO)
     app = connexion.App(__name__, specification_dir="./swagger/")
     app.app.json_encoder = encoder.JSONEncoder
     app.add_api(

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -196,18 +196,18 @@ def patch_connection(service_id, body=None):  # noqa: E501
         db_instance.mark_deleted("breakdowns", f"{service_id}")
         logger.info("Removed connection: ", service_id)
         logger.info(
-            f"Placing new connection {service_id} with te_manager: {current_app.te_manager}"
+            f"Placing new connection {new_service_id} with te_manager: {current_app.te_manager}"
         )
         reason, code = connection_handler.place_connection(current_app.te_manager, body)
         if code == 200:
             db_instance.add_key_value_pair_to_db(
-                "connections", service_id, json.dumps(body)
+                "connections", new_service_id, json.dumps(body)
             )
         logger.info(
-            f"place_connection result: ID: {service_id} reason='{reason}', code={code}"
+            f"place_connection result: ID: {new_service_id} reason='{reason}', code={code}"
         )
         response = {
-            "service_id": service_id,
+            "service_id": new_service_id,
             "status": "OK" if code == 200 else "Failure",
             "reason": reason,
         }

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -185,29 +185,26 @@ def patch_connection(service_id, body=None):  # noqa: E501
 
     logger.info(f"Gathered connexion JSON: {body}")
 
-    new_service_id = str(uuid.uuid4())
-    body["id"] = new_service_id
+    body["id"] = service_id
     logger.info(f"Request has no ID. Generated ID: {service_id}")
 
     try:
         logger.info("Removing connection")
         connection_handler.remove_connection(current_app.te_manager, service_id)
-        db_instance.mark_deleted("connections", f"{service_id}")
-        db_instance.mark_deleted("breakdowns", f"{service_id}")
-        logger.info("Removed connection: ", service_id)
+        logger.info(f"Removed connection: {service_id}")
         logger.info(
-            f"Placing new connection {new_service_id} with te_manager: {current_app.te_manager}"
+            f"Placing new connection {service_id} with te_manager: {current_app.te_manager}"
         )
         reason, code = connection_handler.place_connection(current_app.te_manager, body)
         if code == 200:
             db_instance.add_key_value_pair_to_db(
-                "connections", new_service_id, json.dumps(body)
+                "connections", service_id, json.dumps(body)
             )
         logger.info(
-            f"place_connection result: ID: {new_service_id} reason='{reason}', code={code}"
+            f"place_connection result: ID: {service_id} reason='{reason}', code={code}"
         )
         response = {
-            "service_id": new_service_id,
+            "service_id": service_id,
             "status": "OK" if code == 200 else "Failure",
             "reason": reason,
         }

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import traceback
 from typing import Tuple
 
@@ -181,16 +182,22 @@ class ConnectionHandler:
         historical_connections = self.db_instance.read_from_db(
             "historical_connections", service_id
         )
+        # Current timestamp in seconds
+        timestamp = int(time.time())
 
         if historical_connections:
             historical_connections_list = historical_connections[service_id]
-            historical_connections_list.append(connection_request_str)
+            historical_connections_list.append(
+                json.dumps({timestamp: json.loads(connection_request_str)})
+            )
             self.db_instance.add_key_value_pair_to_db(
                 "historical_connections", service_id, historical_connections_list
             )
         else:
             self.db_instance.add_key_value_pair_to_db(
-                "historical_connections", service_id, [connection_request_str]
+                "historical_connections",
+                service_id,
+                [json.dumps({timestamp: json.loads(connection_request_str)})],
             )
         logger.debug(f"Archived connection: {service_id}")
 

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -131,8 +131,8 @@ class ConnectionHandler:
         Note that we can return early if things fail.  Return value is
         a tuple of the form (reason, HTTP code).
         """
-        for num, val in enumerate(te_manager.get_topology_map().values()):
-            logger.debug(f"TE topology #{num}: {val}")
+        # for num, val in enumerate(te_manager.get_topology_map().values()):
+        #     logger.debug(f"TE topology #{num}: {val}")
 
         graph = te_manager.generate_graph_te()
         if graph is None:
@@ -175,18 +175,18 @@ class ConnectionHandler:
         if not connection_request:
             return
         
+        connection_request_str = connection_request[service_id]
         self.db_instance.delete_one_entry("connections", service_id)
 
         historical_connections = self.db_instance.read_from_db("historical_connections", service_id)
 
         if historical_connections:
-            historical_connections[service_id].append(connection_request)
-            self.db_instance.add_key_value_pair_to_db("historical_connections", service_id, historical_connections)
+            historical_connections_list = historical_connections[service_id]
+            historical_connections_list.append(connection_request_str)
+            self.db_instance.add_key_value_pair_to_db("historical_connections", service_id, historical_connections_list)
         else:
-            self.db_instance.add_key_value_pair_to_db("historical_connections", service_id, [connection_request])
+            self.db_instance.add_key_value_pair_to_db("historical_connections", service_id, [connection_request_str])
         logger.debug(f"Archived connection: {service_id}")
-        print("Getting historical connection")
-        print(historical_connections = self.db_instance.read_from_db("historical_connections", service_id))
 
     def remove_connection(self, te_manager, service_id) -> Tuple[str, int]:
         te_manager.unreserve_vlan(service_id)

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -174,18 +174,24 @@ class ConnectionHandler:
         connection_request = self.db_instance.read_from_db("connections", service_id)
         if not connection_request:
             return
-        
+
         connection_request_str = connection_request[service_id]
         self.db_instance.delete_one_entry("connections", service_id)
 
-        historical_connections = self.db_instance.read_from_db("historical_connections", service_id)
+        historical_connections = self.db_instance.read_from_db(
+            "historical_connections", service_id
+        )
 
         if historical_connections:
             historical_connections_list = historical_connections[service_id]
             historical_connections_list.append(connection_request_str)
-            self.db_instance.add_key_value_pair_to_db("historical_connections", service_id, historical_connections_list)
+            self.db_instance.add_key_value_pair_to_db(
+                "historical_connections", service_id, historical_connections_list
+            )
         else:
-            self.db_instance.add_key_value_pair_to_db("historical_connections", service_id, [connection_request_str])
+            self.db_instance.add_key_value_pair_to_db(
+                "historical_connections", service_id, [connection_request_str]
+            )
         logger.debug(f"Archived connection: {service_id}")
 
     def remove_connection(self, te_manager, service_id) -> Tuple[str, int]:

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -1,11 +1,10 @@
-import json
 import logging
 import os
 from urllib.parse import urlparse
 
 import pymongo
 
-COLLECTION_NAMES = ["topologies", "connections", "breakdowns", "domains", "links"]
+COLLECTION_NAMES = ["topologies", "connections", "breakdowns", "domains", "links", "historical_connections"]
 
 pymongo_logger = logging.getLogger("pymongo")
 pymongo_logger.setLevel(logging.INFO)

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -4,7 +4,14 @@ from urllib.parse import urlparse
 
 import pymongo
 
-COLLECTION_NAMES = ["topologies", "connections", "breakdowns", "domains", "links", "historical_connections"]
+COLLECTION_NAMES = [
+    "topologies",
+    "connections",
+    "breakdowns",
+    "domains",
+    "links",
+    "historical_connections",
+]
 
 pymongo_logger = logging.getLogger("pymongo")
 pymongo_logger.setLevel(logging.INFO)


### PR DESCRIPTION
Relates to: https://github.com/atlanticwave-sdx/sdx-controller/issues/238, https://github.com/atlanticwave-sdx/sdx-controller/issues/235

Add a MongoDB collection "historical_connections" for saving the historical connections. Use service_id as key, a list of connection json as value. Example:
```
'e7fdf472-547d-455c-9c5c-b49c0a0d2974': ['{"name": "VLAN between AMPATH/300 and TENET/300", "endpoints": [{"id": "urn:sdx:port:ampath.net:Novi03:1", "name": "urn:sdx:port:ampath.net:Novi03:1", "vlan_range": 300}, {"id": "urn:sdx:port:tenet.ac.za:Novi07:1", "name": "urn:sdx:port:tenet.ac.za:Novi07:1", "vlan_range": 300}], "id": "e7fdf472-547d-455c-9c5c-b49c0a0d2974"}', '{"name": "VLAN between AMPATH/300 and TENET/300", "endpoints": [{"id": "urn:sdx:port:ampath.net:Novi03:1", "name": "urn:sdx:port:ampath.net:Novi03:1", "vlan_range": 300}, {"id": "urn:sdx:port:tenet.ac.za:Novi07:1", "name": "urn:sdx:port:tenet.ac.za:Novi07:1", "vlan_range": 300}], "id": "e7fdf472-547d-455c-9c5c-b49c0a0d2974"}']
```

And enable using same service_id when doing PATCH 