### PR TITLE
Use topology from database when initialize te manager

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,7 @@ services:
       # MongoDB logs can drown out everything else, so we'll write
       # them to a file.  To watch the log messages, use: `docker exec
       # -it <container> tail -f /var/log/mongodb/mongod.log`.
+      - '--quiet'
       - '--logpath'
       - '/var/log/mongodb/mongod.log'
     healthcheck:

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import threading
 from queue import Queue
+import json
 
 import connexion
 from sdx_pce.topology.temanager import TEManager
@@ -68,7 +69,7 @@ def create_app(run_listener: bool = True):
 
     # Get a handle to PCE.
     app.te_manager = (
-        TEManager(topology_data=topo_val["latest_topo"])
+        TEManager(topology_data=json.loads(topo_val["latest_topo"]))
         if topo_val
         else TEManager(topology_data=None)
     )

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -64,8 +64,15 @@ def create_app(run_listener: bool = True):
     app.db_instance = DbUtils()
     app.db_instance.initialize_db()
 
+    topo_val = app.db_instance.read_from_db("topologies", "latest_topo")
+    print("-----Topo_val-----")
+    print(topo_val["latest_topo"])
     # Get a handle to PCE.
-    app.te_manager = TEManager(topology_data=None)
+    app.te_manager = (
+        TEManager(topology_data=topo_val["latest_topo"])
+        if topo_val
+        else TEManager(topology_data=None)
+    )
 
     # TODO: This is a hack, until we find a better way to get a handle
     # to TEManager from Flask current_app, which are typically

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -65,8 +65,7 @@ def create_app(run_listener: bool = True):
     app.db_instance.initialize_db()
 
     topo_val = app.db_instance.read_from_db("topologies", "latest_topo")
-    print("-----Topo_val-----")
-    print(topo_val["latest_topo"])
+
     # Get a handle to PCE.
     app.te_manager = (
         TEManager(topology_data=topo_val["latest_topo"])

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -1,8 +1,8 @@
+import json
 import logging
 import os
 import threading
 from queue import Queue
-import json
 
 import connexion
 from sdx_pce.topology.temanager import TEManager

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -67,12 +67,11 @@ class LcMessageHandler:
                     "topologies", "num_domain_topos", num_domain_topos
                 )
 
-            logger.info("Adding topology to db.")
-            db_key = "LC-" + str(num_domain_topos)
+        logger.info("Adding topology to db: " + domain_name)
 
-            self.db_instance.add_key_value_pair_to_db(
-                "topologies", db_key, json.dumps(msg_json)
-            )
+        self.db_instance.add_key_value_pair_to_db(
+            "topologies", domain_name, json.dumps(msg_json)
+        )
 
         # TODO: use TEManager API directly; but TEManager does not
         # expose a `get_topology()` method yet.

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -53,7 +53,7 @@ class LcMessageHandler:
                 "domains", "domain_list", domain_list
             )
 
-            logger.info("Adding topo")
+            logger.info("Adding topology to TE manager")
             self.te_manager.add_topology(msg_json)
 
             if self.db_instance.read_from_db("topologies", "num_domain_topos") is None:
@@ -63,16 +63,16 @@ class LcMessageHandler:
                 )
             else:
                 num_domain_topos = len(domain_list)
-                num_domain_topos = int(num_domain_topos) + 1
                 self.db_instance.add_key_value_pair_to_db(
                     "topologies", "num_domain_topos", num_domain_topos
                 )
 
-        logger.info("Adding topo to db.")
-        db_key = "LC-" + str(num_domain_topos)
-        self.db_instance.add_key_value_pair_to_db(
-            "topologies", db_key, json.dumps(msg_json)
-        )
+            logger.info("Adding topology to db.")
+            db_key = "LC-" + str(num_domain_topos)
+
+            self.db_instance.add_key_value_pair_to_db(
+                "topologies", db_key, json.dumps(msg_json)
+            )
 
         # TODO: use TEManager API directly; but TEManager does not
         # expose a `get_topology()` method yet.

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -111,16 +111,16 @@ class RpcConsumer(object):
             num_domain_topos = num_domain_topos_from_db["num_domain_topos"]
             logger.debug("Read num_domain_topos from db: ")
             logger.debug(num_domain_topos)
-            for topo in range(1, num_domain_topos + 1):
-                db_key = f"LC-{topo}"
-                topology = db_instance.read_from_db("topologies", db_key)
+
+            for domain in domain_list:
+                topology = db_instance.read_from_db("topologies", domain)
 
                 if topology:
                     # Get the actual thing minus the Mongo ObjectID.
-                    topology = topology[db_key]
+                    topology = topology[domain]
                     topo_json = json.loads(topology)
                     self.te_manager.add_topology(topo_json)
-                    logger.debug(f"Read {db_key}: {topology}")
+                    logger.debug(f"Read {domain}: {topology}")
 
         while not self._exit_event.is_set():
             # Queue.get() will block until there's an item in the queue.

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -111,7 +111,7 @@ class RpcConsumer(object):
             num_domain_topos = num_domain_topos_from_db["num_domain_topos"]
             logger.debug("Read num_domain_topos from db: ")
             logger.debug(num_domain_topos)
-            for topo in range(1, num_domain_topos + 2):
+            for topo in range(1, num_domain_topos + 1):
                 db_key = f"LC-{topo}"
                 topology = db_instance.read_from_db("topologies", db_key)
 


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/308

When initializing TE manager, we read from DB, if topology already exists, then use the one from DB. Also did some updates to use domain_name as key when saving to DB (in earlier case, we used LC-X for easy iteration of domains).