### PR TITLE
Use LC-X for topo db key

### DIFF
--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -62,13 +62,7 @@ class LcMessageHandler:
                     "topologies", "num_domain_topos", num_domain_topos
                 )
             else:
-                # print("----current domain list----")
-                # print(domain_list)
                 num_domain_topos = len(domain_list)
-                # num_domain_topos = int(num_domain_topos) + 1
-                # self.db_instance.add_key_value_pair_to_db(
-                #     "topologies", "num_domain_topos", num_domain_topos
-                # )
 
         db_key = "LC-" + str(num_domain_topos)
         logger.info(f"Adding topology {db_key} to db.")

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -62,15 +62,18 @@ class LcMessageHandler:
                     "topologies", "num_domain_topos", num_domain_topos
                 )
             else:
+                # print("----current domain list----")
+                # print(domain_list)
                 num_domain_topos = len(domain_list)
-                self.db_instance.add_key_value_pair_to_db(
-                    "topologies", "num_domain_topos", num_domain_topos
-                )
+                # num_domain_topos = int(num_domain_topos) + 1
+                # self.db_instance.add_key_value_pair_to_db(
+                #     "topologies", "num_domain_topos", num_domain_topos
+                # )
 
-        logger.info("Adding topology to db: " + domain_name)
-
+        db_key = "LC-" + str(num_domain_topos)
+        logger.info(f"Adding topology {db_key} to db.")
         self.db_instance.add_key_value_pair_to_db(
-            "topologies", domain_name, json.dumps(msg_json)
+            "topologies", db_key, json.dumps(msg_json)
         )
 
         # TODO: use TEManager API directly; but TEManager does not

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -111,16 +111,16 @@ class RpcConsumer(object):
             num_domain_topos = num_domain_topos_from_db["num_domain_topos"]
             logger.debug("Read num_domain_topos from db: ")
             logger.debug(num_domain_topos)
-
-            for domain in domain_list:
-                topology = db_instance.read_from_db("topologies", domain)
+            for topo in range(1, num_domain_topos + 1):
+                db_key = f"LC-{topo}"
+                topology = db_instance.read_from_db("topologies", db_key)
 
                 if topology:
                     # Get the actual thing minus the Mongo ObjectID.
-                    topology = topology[domain]
+                    topology = topology[db_key]
                     topo_json = json.loads(topology)
                     self.te_manager.add_topology(topo_json)
-                    logger.debug(f"Read {domain}: {topology}")
+                    logger.debug(f"Read {db_key}: {topology}")
 
         while not self._exit_event.is_set():
             # Queue.get() will block until there's an item in the queue.


### PR DESCRIPTION
This PR reverts part of https://github.com/atlanticwave-sdx/sdx-controller/pull/328, to use LC-X as database key. Because using domain name as db key caused some issues on provisioning connection.