### PR TITLE
Add archived connection api

### DIFF
--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -219,5 +219,20 @@ def patch_connection(service_id, body=None):  # noqa: E501
 
     return response, code
 
+
 def get_archived_connections_by_id(service_id):
-    return "Do some magic"
+    """
+    List archived connection by ID.
+
+    :param service_id: ID of connection that needs to be fetched
+    :type service_id: str
+
+    :rtype: Connection
+    """
+
+    value = get_connection_status(db_instance, service_id)
+
+    if not value:
+        return "Connection not found", 404
+
+    return value

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -70,7 +70,7 @@ def delete_connection(service_id):
     return "OK", 200
 
 
-def getconnection_by_id(service_id):
+def get_connection_by_id(service_id):
     """
     Find connection by ID.
 
@@ -88,7 +88,7 @@ def getconnection_by_id(service_id):
     return value
 
 
-def getconnections():  # noqa: E501
+def get_connections():  # noqa: E501
     """List all connections
 
     connection details # noqa: E501
@@ -218,3 +218,6 @@ def patch_connection(service_id, body=None):  # noqa: E501
         return f"Failed, reason: {e}", 500
 
     return response, code
+
+def get_archived_connections_by_id(service_id):
+    return "Do some magic"

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -271,6 +271,14 @@ class ConnectionHandler:
                     logger.debug(connection)
                     self.place_connection(te_manager, connection)
 
+    def get_archived_connections(self, service_id: str):
+        historical_connections = self.db_instance.read_from_db(
+            "historical_connections", service_id
+        )
+        if not historical_connections:
+            return None
+        return historical_connections[service_id]
+
 
 def get_connection_status(db, service_id: str):
     """

--- a/sdx_controller/swagger/swagger.yaml
+++ b/sdx_controller/swagger/swagger.yaml
@@ -159,7 +159,7 @@ paths:
       - l2vpn
       summary: List all l2vpn connections
       description: connection details
-      operationId: getconnections
+      operationId: get_connections
       responses:
         "200":
           description: successful operation
@@ -204,7 +204,7 @@ paths:
       - l2vpn
       summary: Find l2vpn connection by ID
       description: connection details
-      operationId: getconnection_by_id
+      operationId: get_connection_by_id
       parameters:
       - name: service_id
         in: path
@@ -283,6 +283,38 @@ paths:
                 $ref: '#/components/schemas/connection'
         "400":
           description: Invalid Connection
+      x-openapi-router-controller: sdx_controller.controllers.l2vpn_controller
+  /l2vpn/1.0/{service_id}/archived:
+    get:
+      tags:
+      - l2vpn
+      summary: Get list of l2vpn connection historical events by ID
+      description: connection historical events
+      operationId: get_archived_connections_by_id
+      parameters:
+      - name: service_id
+        in: path
+        description: ID of l2vpn connection for querying history
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connection'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/connection'
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: connection not found
       x-openapi-router-controller: sdx_controller.controllers.l2vpn_controller
   /user:
     post:


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/238

This PR adds an API to query archived connections for a specific service ID. It may not make sense to be able to query all archived connections at this point, because there can be plenty of connections, resulting a huge response.