### PR TITLE
Read connection from db

### DIFF
--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -80,12 +80,12 @@ def getconnection_by_id(service_id):
     :rtype: Connection
     """
 
-    value = get_connection_status(db_instance, service_id)
+    value = db_instance.read_from_db("connections", service_id)
 
     if not value:
         return "Connection not found", 404
 
-    return value
+    return json.loads(value[service_id])
 
 
 def getconnections():  # noqa: E501


### PR DESCRIPTION
We changed [this part](https://github.com/atlanticwave-sdx/sdx-controller/commit/b801c7cf4c29802c9e1fbe8dd80dbf235043a841#diff-593c594a01c4e184cecde995719e7d931bcf2a2d4ed01bbd9e740e4d7684374dL80) to get connection using `get_connection_status()`. But this causes some inconsistency if connection contains some extra fields, such as `qoe_metrics` from this request:

```
{
    "description": "This is an example to demonstrate a L2VPN with optional attributes",
    "endpoints": [
      {
        "id": "urn:sdx:port:ampath.net:Novi03:1",
        "name": "urn:sdx:port:ampath.net:Novi03:1",
        "vlan_range": "any"
      },
      {
        "id": "urn:sdx:port:tenet.ac.za:Novi07:1",
        "name": "urn:sdx:port:tenet.ac.za:Novi07:1",
        "vlan_range": "any"
      }
    ],
    "service_id": "c45ab569-c4f3-4e2e-87c5-fecddaf41966",
    "name": "fabric new test1",
    "qos_metrics": {
      "max_delay": {
        "strict": true,
        "value": 150
      },
      "min_bw": {
        "strict": false,
        "value": 5
      }
    }
}
```
This PR changes back to read connection from db when get connection by id.