### PR TITLE
Use get_connection_status when listing connections

### DIFF
--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -101,7 +101,7 @@ def get_connections():  # noqa: E501
     return_values = {}
     for connection in values:
         service_id = next(iter(connection))
-        return_values[service_id] = json.loads(connection[service_id])
+        return_values[service_id] = get_connection_status(db_instance, service_id)
     return return_values
 
 


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/333, https://github.com/atlanticwave-sdx/sdx-controller/issues/336

Call `get_connection_status()` for all connections, when listing connections.