### PR TITLE
Do not duplicate service_id when listing connections

### DIFF
--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -101,7 +101,9 @@ def get_connections():  # noqa: E501
     return_values = {}
     for connection in values:
         service_id = next(iter(connection))
-        return_values[service_id] = get_connection_status(db_instance, service_id)[service_id]
+        return_values[service_id] = get_connection_status(db_instance, service_id)[
+            service_id
+        ]
     return return_values
 
 

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -101,7 +101,7 @@ def get_connections():  # noqa: E501
     return_values = {}
     for connection in values:
         service_id = next(iter(connection))
-        return_values[service_id] = get_connection_status(db_instance, service_id)
+        return_values[service_id] = get_connection_status(db_instance, service_id)[service_id]
     return return_values
 
 


### PR DESCRIPTION
A quick fix when listing connections. Previously:
```
{
  "a0e32889-ec1f-426f-9881-d071d1cd301e": {
    "a0e32889-ec1f-426f-9881-d071d1cd301e": {
    "description": null,
    "endpoints": [
      {
        "port_id": "urn:sdx:port:ampath.net:Novi03:1",
        "vlan": "101"
      },
      {
        "port_id": "urn:sdx:port:ampath.net:Novi03:1",
        "vlan": "4095"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Novi07:1",
        "vlan": "4095"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Novi07:1",
        "vlan": "101"
      }
    ],
    "name": "fabrictest1",
    "service_id": "20caef72-b799-4781-9b80-e6c5832376f9"
  }
  }
}
```
new:
```
{
  "a0e32889-ec1f-426f-9881-d071d1cd301e": {
    "description": null,
    "endpoints": [
      {
        "port_id": "urn:sdx:port:ampath.net:Novi03:1",
        "vlan": "101"
      },
      {
        "port_id": "urn:sdx:port:ampath.net:Novi03:1",
        "vlan": "4095"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Novi07:1",
        "vlan": "4095"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Novi07:1",
        "vlan": "101"
      }
    ],
    "name": "fabrictest1",
    "service_id": "20caef72-b799-4781-9b80-e6c5832376f9"
  }
}
```