### PR TITLE
Cleanup topology handling logic

### DIFF
--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -57,10 +57,10 @@ class LcMessageHandler:
             logger.info("Adding topology to TE manager")
             self.te_manager.add_topology(msg_json)
             num_domain_topos = len(domain_list)
-        
+
         self.db_instance.add_key_value_pair_to_db(
-                "topologies", "num_domain_topos", num_domain_topos
-            )
+            "topologies", "num_domain_topos", num_domain_topos
+        )
         db_key = "LC-" + str(num_domain_topos)
         logger.info(f"Adding topology {db_key} to db.")
         self.db_instance.add_key_value_pair_to_db(

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -85,22 +85,17 @@ class RpcConsumer(object):
 
         latest_topo = {}
         domain_list = []
-        num_domain_topos = 0
 
         # This part reads from DB when SDX controller initially starts.
-        # It looks for domain_list, and num_domain_topos, if they are already in DB,
+        # It looks for domain_list, if already in DB,
         # Then use the existing ones from DB.
         domain_list_from_db = db_instance.read_from_db("domains", "domain_list")
         latest_topo_from_db = db_instance.read_from_db("topologies", "latest_topo")
-        num_domain_topos_from_db = db_instance.read_from_db(
-            "topologies", "num_domain_topos"
-        )
 
         if domain_list_from_db:
             domain_list = domain_list_from_db["domain_list"]
             logger.debug("Domain list already exists in db: ")
             logger.debug(domain_list)
-            num_domain_topos = len(domain_list)
 
         if latest_topo_from_db:
             latest_topo = latest_topo_from_db["latest_topo"]
@@ -108,22 +103,18 @@ class RpcConsumer(object):
             logger.debug(latest_topo)
 
         # If topologies already saved in db, use them to initialize te_manager
-        if num_domain_topos_from_db:
-            num_domain_topos = num_domain_topos_from_db["num_domain_topos"]
-            logger.debug("Read num_domain_topos from db: ")
-            logger.debug(num_domain_topos)
-            for topo in range(1, num_domain_topos + 1):
-                db_key = f"LC-{topo}"
-                topology = db_instance.read_from_db("topologies", db_key)
+        if domain_list:
+            for domain in domain_list:
+                topology = db_instance.read_from_db("topologies", domain)
 
                 if not topology:
                     continue
 
                 # Get the actual thing minus the Mongo ObjectID.
-                topology = topology[db_key]
+                topology = topology[domain]
                 topo_json = json.loads(topology)
                 self.te_manager.add_topology(topo_json)
-                logger.debug(f"Read {db_key}: {topology}")
+                logger.debug(f"Read {domain}: {topology}")
 
         while not self._exit_event.is_set():
             # Queue.get() will block until there's an item in the queue.

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -134,19 +134,18 @@ class RpcConsumer(object):
                 HEARTBEAT_ID += 1
                 logger.debug("Heart beat received. ID: " + str(HEARTBEAT_ID))
                 continue
-            
+
             if not parse_helper.is_json(msg):
                 continue
 
             if "version" not in str(msg):
                 logger.info("Got message (NO VERSION) from MQ: " + str(msg))
-            
+
             lc_message_handler.process_lc_json_msg(
                 msg,
                 latest_topo,
                 domain_list,
             )
-                
 
     def stop_threads(self):
         """


### PR DESCRIPTION
We used to use LC-1,2,3 to represent the LCs, to be easier to loop through the topologies from db when SDX starts up. Now we have the list of LC domain names saved in db, so we don't need the LC counter any more. This can simplify the logic for handling topologies.