### PR TITLE
Bump pce version up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@3.0.0.dev3",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@3.0.0.dev4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Resolves #350.  Note that the actual fix is in the version of PCE that replaces asserts with error checks and log statements.