### PR TITLE
Roll back patch when fail

### DIFF
--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -232,11 +232,13 @@ def patch_connection(service_id, body=None):  # noqa: E501
                 f"Failed to place new connection. ID: {service_id} reason='{reason}', code={code}"
             )
             logger.info("Rolling back to old connection.")
-            print(rollback_conn_body)
+
             if rollback_conn_body:
+                conn_request = json.loads(rollback_conn_body[service_id])
+                conn_request["id"] = service_id
                 rollback_conn_reason, rollback_conn_code = (
                     connection_handler.place_connection(
-                        current_app.te_manager, rollback_conn_body
+                        current_app.te_manager, conn_request
                     )
                 )
                 if rollback_conn_code // 100 == 2:

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -199,7 +199,16 @@ def patch_connection(service_id, body=None):  # noqa: E501
 
     try:
         logger.info("Removing connection")
-        connection_handler.remove_connection(current_app.te_manager, service_id)
+        remove_conn_reason, remove_conn_code = connection_handler.remove_connection(current_app.te_manager, service_id)
+        
+        if remove_conn_code // 100 != 2:
+            response = {
+                "service_id": service_id,
+                "status": "Failure",
+                "reason": remove_conn_reason,
+            }
+            return response, remove_conn_code
+        
         logger.info(f"Removed connection: {service_id}")
         logger.info(
             f"Placing new connection {service_id} with te_manager: {current_app.te_manager}"
@@ -211,9 +220,21 @@ def patch_connection(service_id, body=None):  # noqa: E501
             )
             # Service created successfully
             code = 201
-        logger.info(
-            f"place_connection result: ID: {service_id} reason='{reason}', code={code}"
-        )
+            logger.info(
+                f"Place connection result: ID: {service_id} reason='{reason}', code={code}"
+            )
+        else:
+            logger.info(f"Failed to place new connection. ID: {service_id} reason='{reason}', code={code}")
+            logger.info("Rolling back to old connection.")
+            rollback_conn_body = db_instance.read_from_db("connections", service_id)
+            rollback_conn_reason, rollback_conn_code = connection_handler.place_connection(current_app.te_manager, rollback_conn_body)
+            if rollback_conn_code // 100 == 2:
+                db_instance.add_key_value_pair_to_db(
+                    "connections", service_id, json.dumps(rollback_conn_body)
+                )
+            logger.info(
+                f"Roll back connection result: ID: {service_id} reason='{rollback_conn_reason}', code={rollback_conn_code}"
+            )
         response = {
             "service_id": service_id,
             "status": "OK" if code // 100 == 2 else "Failure",


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/334

For a PATCH, we first delete, then create a new connection. If delete was successful, but create failed, the old connection will be deleted, without a replacement connection.

This PR rolls back to the last successful connection if placing new connection fails. Response is like this:

```
{
  "reason": "Could not generate a traffic matrix",
  "service_id": "b8bfc596-b298-4222-aa45-846a592504c9",
  "status": "Failure, rolled back to last successful L2VPN connection"
}
```