### PR TITLE
Listen to connection OXP response

### DIFF
--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -137,8 +137,6 @@ def place_connection(body):
     logger.info(
         f"Handling request {service_id} with te_manager: {current_app.te_manager}"
     )
-    print("-----PLACE CONNECTION-----")
-    print(body)
     reason, code = connection_handler.place_connection(current_app.te_manager, body)
 
     if code // 100 == 2:

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -109,7 +109,11 @@ class ConnectionHandler:
                 f"Doing '{operation}' operation for '{link}' with exchange_name: {exchange_name}, "
                 f"routing_key: {domain_name}"
             )
-            mq_link = {"operation": operation, "service_id": connection_request.get("id"), "link": link}
+            mq_link = {
+                "operation": operation,
+                "service_id": connection_request.get("id"),
+                "link": link,
+            }
             producer = TopicQueueProducer(
                 timeout=5, exchange_name=exchange_name, routing_key=domain_name
             )

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -109,7 +109,7 @@ class ConnectionHandler:
                 f"Doing '{operation}' operation for '{link}' with exchange_name: {exchange_name}, "
                 f"routing_key: {domain_name}"
             )
-            mq_link = {"operation": operation, "link": link}
+            mq_link = {"operation": operation, "service_id": connection_request.get("id"), "link": link}
             producer = TopicQueueProducer(
                 timeout=5, exchange_name=exchange_name, routing_key=domain_name
             )

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -382,7 +382,6 @@ def get_connection_status(db, service_id: str):
         notifications = request_dict.get("notifications")
         oxp_response_code = request_dict.get("oxp_response_code")
         oxp_response = request_dict.get("oxp_response")
-        print(f"request_dict: {request_dict}")
         if request_dict.get("endpoints") is not None:  # spec version 2.0.0
             request_endpoints = request_dict.get("endpoints")
             request_uni_a = request_endpoints[0]

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -376,6 +376,8 @@ def get_connection_status(db, service_id: str):
         qos_metrics = request_dict.get("qos_metrics")
         scheduling = request_dict.get("scheduling")
         notifications = request_dict.get("notifications")
+        oxp_response_code = request_dict.get("oxp_response_code")
+        oxp_response = request_dict.get("oxp_response")
         print(f"request_dict: {request_dict}")
         if request_dict.get("endpoints") is not None:  # spec version 2.0.0
             request_endpoints = request_dict.get("endpoints")
@@ -468,6 +470,12 @@ def get_connection_status(db, service_id: str):
 
     if notifications:
         response[service_id]["notifications"] = notifications
+
+    if oxp_response_code:
+        response[service_id]["oxp_response_code"] = oxp_response_code
+
+    if oxp_response:
+        response[service_id]["oxp_response"] = oxp_response
 
     logger.info(f"Formed a response: {response}")
 

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -22,6 +22,27 @@ class LcMessageHandler:
     ):
         logger.info("MQ received message:" + str(msg))
         msg_json = json.loads(msg)
+
+        if msg_json.get("msg_type") and msg_json["msg_type"] == "oxp_conn_response":
+            logger.info("Received OXP connection response.")
+            service_id = msg_json.get("service_id")
+
+            if not service_id:
+                return
+            
+            connection = self.db_instance.read_from_db("connections", service_id)
+
+            if not connection:
+                return
+            
+            connection_json = json.loads(connection[service_id])
+            connection_json["oxp_response_code"] = msg_json.get("oxp_response_code")
+            connection_json["oxp_response"] = msg_json.get("oxp_response")
+            self.db_instance.add_key_value_pair_to_db("connections", service_id, json.dumps(connection_json))
+            logger.info("Connection updated: " + service_id)
+            print(self.db_instance.read_from_db("connections", service_id))
+            return
+
         msg_id = msg_json["id"]
         msg_version = msg_json["version"]
 

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -42,7 +42,6 @@ class LcMessageHandler:
                 "connections", service_id, json.dumps(connection_json)
             )
             logger.info("Connection updated: " + service_id)
-            print(self.db_instance.read_from_db("connections", service_id))
             return
 
         msg_id = msg_json["id"]

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -29,16 +29,18 @@ class LcMessageHandler:
 
             if not service_id:
                 return
-            
+
             connection = self.db_instance.read_from_db("connections", service_id)
 
             if not connection:
                 return
-            
+
             connection_json = json.loads(connection[service_id])
             connection_json["oxp_response_code"] = msg_json.get("oxp_response_code")
             connection_json["oxp_response"] = msg_json.get("oxp_response")
-            self.db_instance.add_key_value_pair_to_db("connections", service_id, json.dumps(connection_json))
+            self.db_instance.add_key_value_pair_to_db(
+                "connections", service_id, json.dumps(connection_json)
+            )
             logger.info("Connection updated: " + service_id)
             print(self.db_instance.read_from_db("connections", service_id))
             return

--- a/sdx_controller/messaging/topic_queue_producer.py
+++ b/sdx_controller/messaging/topic_queue_producer.py
@@ -64,13 +64,6 @@ class TopicQueueProducer(object):
             self.response = body
 
     def call(self, body):
-        # if not self.connection or self.connection.is_closed:
-        #     # print("Reopening connection...")
-        #     self.connection = pika.BlockingConnection(pika.ConnectionParameters(host=MQ_HOST))
-        #     self.channel = self.connection.channel()
-        #     # print("Connection reopened.")
-        #     # channel.exchange_declare(exchange=self.exchange_name)
-
         self.response = None
         self.corr_id = str(uuid.uuid4())
         self.channel.exchange_declare(


### PR DESCRIPTION
Relates to: https://github.com/atlanticwave-sdx/sdx-lc/issues/162

When LC sends OXP response to SDX controller, the controller will update the corresponding connection entry to include the oxp_response and oxp_response_code fields. 

When sending breakdown to the LC, now the link includes service_id, so we can track which connection should be updated with the response.