### PR TITLE
Adding log level configuration from env variable

### DIFF
--- a/bapm_server/__main__.py
+++ b/bapm_server/__main__.py
@@ -44,7 +44,7 @@ def start_consumer(thread_queue, es):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.getLevelName(os.getenv("LOG_LEVEL", "DEBUG")))
 
     es = Elasticsearch([{"host": ES_HOST, "port": ES_PORT}])
 

--- a/bapm_server/bapm_consumer.py
+++ b/bapm_server/bapm_consumer.py
@@ -204,7 +204,6 @@ class BAPMConsumer(object):
 
 
 def main():
-    # logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
     amqp_url = "amqp://guest:guest@aw-sdx-monitor.renci.org:5672/%2F"
 
     thread_queue = Queue()

--- a/bapm_server/bapm_publisher.py
+++ b/bapm_server/bapm_publisher.py
@@ -3,6 +3,7 @@
 import functools
 import json
 import logging
+import os
 
 import pika
 from pika.exchange_type import ExchangeType
@@ -235,7 +236,9 @@ class BAPMPublisher(object):
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
+    logging.basicConfig(
+        level=logging.getLevelName(os.getenv("LOG_LEVEL", "DEBUG")), format=LOG_FORMAT
+    )
 
     # Connect to localhost:5672 as guest with the password guest and virtual host "/" (%2F)
     publisher = BAPMPublisher("amqp://guest:guest@aw-sdx-monitor.renci.org:5672/%2F")

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -14,6 +14,7 @@ from sdx_controller.utils.db_utils import DbUtils
 logger = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)
 LOG_FILE = os.environ.get("LOG_FILE")
+LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG")
 
 
 def create_rpc_thread(app):
@@ -50,9 +51,9 @@ def create_app(run_listener: bool = True):
     threads, which is when run_listener param might be useful.
     """
     if LOG_FILE:
-        logging.basicConfig(filename=LOG_FILE, level=logging.DEBUG)
+        logging.basicConfig(filename=LOG_FILE, level=logging.getLevelName(LOG_LEVEL))
     else:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(level=logging.getLevelName(LOG_LEVEL))
 
     logging.getLogger("sdx_pce.topology.temanager").setLevel(logging.INFO)
     app = connexion.App(__name__, specification_dir="./swagger/")

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import uuid
 
 import connexion
@@ -21,7 +22,7 @@ LOG_FORMAT = (
 )
 logger = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.getLevelName(os.getenv("LOG_LEVEL", "DEBUG")))
 
 # Get DB connection and tables set up.
 db_instance = DbUtils()

--- a/sdx_controller/messaging/topic_queue_producer.py
+++ b/sdx_controller/messaging/topic_queue_producer.py
@@ -84,8 +84,6 @@ class TopicQueueProducer(object):
 
 
 if __name__ == "__main__":
-    # logging.basicConfig(level=logging.DEBUG)
-
     producer = TopicQueueProducer(5, "connection", "lc1_q1")
     body = "test body"
     print("Published Message: {}".format(body))

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -53,7 +53,7 @@ class DbUtils(object):
             )
 
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.DEBUG)
+        self.logger.setLevel(logging.getLevelName(os.getenv("LOG_LEVEL", "DEBUG")))
 
         # Log DB URI, without a password.
         self.logger.info(f"[DB] Using {obfuscate_password_in_uri(mongo_connstring)}")


### PR DESCRIPTION
Fix #394 

### Description of the change

As discussed during the All Hands Meeting, it would be nice if we have means to change the log level of the SDX components for production environment. In production, having the log level hardcoded to DEBUG is not recommended. With this PR, the SDX-Controller operator can now set an environment variable called `LOG_LEVEL` and change this behavior.

For backward compatibility, the LOG_LEVEL defaults to "DEBUG" just as current behavior.