### PR TITLE
Change strings to consts

### DIFF
--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -9,8 +9,8 @@ from sdx_pce.topology.temanager import TEManager
 
 from sdx_controller import encoder
 from sdx_controller.messaging.rpc_queue_consumer import RpcConsumer
+from sdx_controller.utils.constants import Constants, MongoCollections
 from sdx_controller.utils.db_utils import DbUtils
-from sdx_controller.utils.constants import MongoCollections, Constants
 
 logger = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -10,7 +10,7 @@ from sdx_pce.topology.temanager import TEManager
 from sdx_controller import encoder
 from sdx_controller.messaging.rpc_queue_consumer import RpcConsumer
 from sdx_controller.utils.db_utils import DbUtils
-from sdx_controller.utils.constants import MongoCollections
+from sdx_controller.utils.constants import MongoCollections, Constants
 
 logger = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)
@@ -67,12 +67,12 @@ def create_app(run_listener: bool = True):
     app.db_instance.initialize_db()
 
     topo_val = app.db_instance.read_from_db(
-        MongoCollections.TOPOLOGIES.value, "latest_topo"
+        MongoCollections.TOPOLOGIES, Constants.LATEST_TOPO
     )
 
     # Get a handle to PCE.
     app.te_manager = (
-        TEManager(topology_data=json.loads(topo_val["latest_topo"]))
+        TEManager(topology_data=json.loads(topo_val[Constants.LATEST_TOPO]))
         if topo_val
         else TEManager(topology_data=None)
     )

--- a/sdx_controller/__init__.py
+++ b/sdx_controller/__init__.py
@@ -10,6 +10,7 @@ from sdx_pce.topology.temanager import TEManager
 from sdx_controller import encoder
 from sdx_controller.messaging.rpc_queue_consumer import RpcConsumer
 from sdx_controller.utils.db_utils import DbUtils
+from sdx_controller.utils.constants import MongoCollections
 
 logger = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)
@@ -65,7 +66,9 @@ def create_app(run_listener: bool = True):
     app.db_instance = DbUtils()
     app.db_instance.initialize_db()
 
-    topo_val = app.db_instance.read_from_db("topologies", "latest_topo")
+    topo_val = app.db_instance.read_from_db(
+        MongoCollections.TOPOLOGIES.value, "latest_topo"
+    )
 
     # Get a handle to PCE.
     app.te_manager = (

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -65,7 +65,7 @@ def delete_connection(service_id):
             return "Did not find connection", 404
         connection_handler.remove_connection(current_app.te_manager, service_id)
         db_instance.mark_deleted(MongoCollections.CONNECTIONS.value, f"{service_id}")
-        db_instance.mark_deleted("breakdowns", f"{service_id}")
+        db_instance.mark_deleted(MongoCollections.BREAKDOWNS.value, f"{service_id}")
     except Exception as e:
         logger.info(f"Delete failed (connection id: {service_id}): {e}")
         return f"Failed, reason: {e}", 500

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -13,8 +13,8 @@ from sdx_controller.handlers.connection_handler import (
 from sdx_controller.models.connection import Connection  # noqa: E501
 from sdx_controller.models.l2vpn_body import L2vpnBody  # noqa: E501
 from sdx_controller.models.l2vpn_service_id_body import L2vpnServiceIdBody  # noqa: E501
-from sdx_controller.utils.db_utils import DbUtils
 from sdx_controller.utils.constants import MongoCollections
+from sdx_controller.utils.db_utils import DbUtils
 
 LOG_FORMAT = (
     "%(levelname) -10s %(asctime)s %(name) -30s %(funcName) "

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -59,13 +59,13 @@ def delete_connection(service_id):
         #
         # https://github.com/atlanticwave-sdx/pce/issues/180
         connection = db_instance.read_from_db(
-            MongoCollections.CONNECTIONS.value, f"{service_id}"
+            MongoCollections.CONNECTIONS, f"{service_id}"
         )
         if not connection:
             return "Did not find connection", 404
         connection_handler.remove_connection(current_app.te_manager, service_id)
-        db_instance.mark_deleted(MongoCollections.CONNECTIONS.value, f"{service_id}")
-        db_instance.mark_deleted(MongoCollections.BREAKDOWNS.value, f"{service_id}")
+        db_instance.mark_deleted(MongoCollections.CONNECTIONS, f"{service_id}")
+        db_instance.mark_deleted(MongoCollections.BREAKDOWNS, f"{service_id}")
     except Exception as e:
         logger.info(f"Delete failed (connection id: {service_id}): {e}")
         return f"Failed, reason: {e}", 500
@@ -98,9 +98,7 @@ def get_connections():  # noqa: E501
 
     :rtype: Connection
     """
-    values = db_instance.get_all_entries_in_collection(
-        MongoCollections.CONNECTIONS.value
-    )
+    values = db_instance.get_all_entries_in_collection(MongoCollections.CONNECTIONS)
     if not values:
         return "No connection was found", 404
     return_values = {}
@@ -146,7 +144,7 @@ def place_connection(body):
 
     if code // 100 == 2:
         db_instance.add_key_value_pair_to_db(
-            MongoCollections.CONNECTIONS.value, service_id, json.dumps(body)
+            MongoCollections.CONNECTIONS, service_id, json.dumps(body)
         )
         # Service created successfully
         code = 201
@@ -187,9 +185,7 @@ def patch_connection(service_id, body=None):  # noqa: E501
 
     :rtype: Connection
     """
-    value = db_instance.read_from_db(
-        MongoCollections.CONNECTIONS.value, f"{service_id}"
-    )
+    value = db_instance.read_from_db(MongoCollections.CONNECTIONS, f"{service_id}")
     if not value:
         return "Connection not found", 404
 
@@ -207,7 +203,7 @@ def patch_connection(service_id, body=None):  # noqa: E501
         logger.info("Removing connection")
         # Get roll back connection before removing connection
         rollback_conn_body = db_instance.read_from_db(
-            MongoCollections.CONNECTIONS.value, service_id
+            MongoCollections.CONNECTIONS, service_id
         )
         remove_conn_reason, remove_conn_code = connection_handler.remove_connection(
             current_app.te_manager, service_id
@@ -234,7 +230,7 @@ def patch_connection(service_id, body=None):  # noqa: E501
 
     if code // 100 == 2:
         db_instance.add_key_value_pair_to_db(
-            MongoCollections.CONNECTIONS.value, service_id, json.dumps(body)
+            MongoCollections.CONNECTIONS, service_id, json.dumps(body)
         )
         # Service created successfully
         code = 201
@@ -268,7 +264,7 @@ def patch_connection(service_id, body=None):  # noqa: E501
         )
         if rollback_conn_code // 100 == 2:
             db_instance.add_key_value_pair_to_db(
-                MongoCollections.CONNECTIONS.value, service_id, json.dumps(conn_request)
+                MongoCollections.CONNECTIONS, service_id, json.dumps(conn_request)
             )
         logger.info(
             f"Roll back connection result: ID: {service_id} reason='{rollback_conn_reason}', code={rollback_conn_code}"

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -14,6 +14,7 @@ from sdx_controller.models.connection import Connection  # noqa: E501
 from sdx_controller.models.l2vpn_body import L2vpnBody  # noqa: E501
 from sdx_controller.models.l2vpn_service_id_body import L2vpnServiceIdBody  # noqa: E501
 from sdx_controller.utils.db_utils import DbUtils
+from sdx_controller.utils.constants import MongoCollections
 
 LOG_FORMAT = (
     "%(levelname) -10s %(asctime)s %(name) -30s %(funcName) "
@@ -57,11 +58,13 @@ def delete_connection(service_id):
         # service_id is not found.  This should in fact be an error.
         #
         # https://github.com/atlanticwave-sdx/pce/issues/180
-        connection = db_instance.read_from_db("connections", f"{service_id}")
+        connection = db_instance.read_from_db(
+            MongoCollections.CONNECTIONS.value, f"{service_id}"
+        )
         if not connection:
             return "Did not find connection", 404
         connection_handler.remove_connection(current_app.te_manager, service_id)
-        db_instance.mark_deleted("connections", f"{service_id}")
+        db_instance.mark_deleted(MongoCollections.CONNECTIONS.value, f"{service_id}")
         db_instance.mark_deleted("breakdowns", f"{service_id}")
     except Exception as e:
         logger.info(f"Delete failed (connection id: {service_id}): {e}")
@@ -95,7 +98,9 @@ def get_connections():  # noqa: E501
 
     :rtype: Connection
     """
-    values = db_instance.get_all_entries_in_collection("connections")
+    values = db_instance.get_all_entries_in_collection(
+        MongoCollections.CONNECTIONS.value
+    )
     if not values:
         return "No connection was found", 404
     return_values = {}
@@ -141,7 +146,7 @@ def place_connection(body):
 
     if code // 100 == 2:
         db_instance.add_key_value_pair_to_db(
-            "connections", service_id, json.dumps(body)
+            MongoCollections.CONNECTIONS.value, service_id, json.dumps(body)
         )
         # Service created successfully
         code = 201
@@ -182,7 +187,9 @@ def patch_connection(service_id, body=None):  # noqa: E501
 
     :rtype: Connection
     """
-    value = db_instance.read_from_db("connections", f"{service_id}")
+    value = db_instance.read_from_db(
+        MongoCollections.CONNECTIONS.value, f"{service_id}"
+    )
     if not value:
         return "Connection not found", 404
 
@@ -199,7 +206,9 @@ def patch_connection(service_id, body=None):  # noqa: E501
     try:
         logger.info("Removing connection")
         # Get roll back connection before removing connection
-        rollback_conn_body = db_instance.read_from_db("connections", service_id)
+        rollback_conn_body = db_instance.read_from_db(
+            MongoCollections.CONNECTIONS.value, service_id
+        )
         remove_conn_reason, remove_conn_code = connection_handler.remove_connection(
             current_app.te_manager, service_id
         )
@@ -225,7 +234,7 @@ def patch_connection(service_id, body=None):  # noqa: E501
 
     if code // 100 == 2:
         db_instance.add_key_value_pair_to_db(
-            "connections", service_id, json.dumps(body)
+            MongoCollections.CONNECTIONS.value, service_id, json.dumps(body)
         )
         # Service created successfully
         code = 201
@@ -259,7 +268,7 @@ def patch_connection(service_id, body=None):  # noqa: E501
         )
         if rollback_conn_code // 100 == 2:
             db_instance.add_key_value_pair_to_db(
-                "connections", service_id, json.dumps(conn_request)
+                MongoCollections.CONNECTIONS.value, service_id, json.dumps(conn_request)
             )
         logger.info(
             f"Roll back connection result: ID: {service_id} reason='{rollback_conn_reason}', code={rollback_conn_code}"

--- a/sdx_controller/controllers/topology_controller.py
+++ b/sdx_controller/controllers/topology_controller.py
@@ -2,6 +2,7 @@ from flask import current_app
 from sdx_pce.topology.grenmlconverter import GrenmlConverter
 
 from sdx_controller.utils.db_utils import DbUtils
+from sdx_controller.utils.constants import MongoCollections
 
 # Get DB connection and tables set up.
 db_instance = DbUtils()
@@ -16,7 +17,9 @@ def get_topology():  # noqa: E501
 
     :rtype: str
     """
-    topo_val = db_instance.read_from_db("topologies", "latest_topo")
+    topo_val = db_instance.read_from_db(
+        MongoCollections.TOPOLOGIES.value, "latest_topo"
+    )
 
     # TODO: this is a workaround because of the way we read values
     # from MongoDB; refactor and test this more.

--- a/sdx_controller/controllers/topology_controller.py
+++ b/sdx_controller/controllers/topology_controller.py
@@ -1,8 +1,8 @@
 from flask import current_app
 from sdx_pce.topology.grenmlconverter import GrenmlConverter
 
+from sdx_controller.utils.constants import Constants, MongoCollections
 from sdx_controller.utils.db_utils import DbUtils
-from sdx_controller.utils.constants import MongoCollections, Constants
 
 # Get DB connection and tables set up.
 db_instance = DbUtils()

--- a/sdx_controller/controllers/topology_controller.py
+++ b/sdx_controller/controllers/topology_controller.py
@@ -2,7 +2,7 @@ from flask import current_app
 from sdx_pce.topology.grenmlconverter import GrenmlConverter
 
 from sdx_controller.utils.db_utils import DbUtils
-from sdx_controller.utils.constants import MongoCollections
+from sdx_controller.utils.constants import MongoCollections, Constants
 
 # Get DB connection and tables set up.
 db_instance = DbUtils()
@@ -18,7 +18,7 @@ def get_topology():  # noqa: E501
     :rtype: str
     """
     topo_val = db_instance.read_from_db(
-        MongoCollections.TOPOLOGIES.value, "latest_topo"
+        MongoCollections.TOPOLOGIES, Constants.LATEST_TOPO
     )
 
     # TODO: this is a workaround because of the way we read values
@@ -26,7 +26,7 @@ def get_topology():  # noqa: E501
     if not topo_val:
         return None
 
-    return topo_val["latest_topo"]
+    return topo_val[Constants.LATEST_TOPO]
 
 
 def get_topologyby_grenml():  # noqa: E501
@@ -61,8 +61,10 @@ def topology_version(topology_id):  # noqa: E501
 
 
 def get_topology_domains():
-    domain_list = db_instance.read_from_db("domains", "domain_list")
+    domain_list = db_instance.read_from_db(
+        MongoCollections.DOMAINS, Constants.DOMAIN_LIST
+    )
     if not domain_list:
         return []
 
-    return domain_list["domain_list"]
+    return domain_list[Constants.DOMAIN_LIST]

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -189,7 +189,7 @@ class ConnectionHandler:
                 solution, connection_request
             )
             self.db_instance.add_key_value_pair_to_db(
-                "breakdowns", connection_request["id"], breakdown
+                MongoCollections.BREAKDOWNS.value, connection_request["id"], breakdown
             )
             status, code = self._send_breakdown_to_lc(
                 breakdown, "post", connection_request
@@ -250,7 +250,9 @@ class ConnectionHandler:
 
         connection_request = connection_request[service_id]
 
-        breakdown = self.db_instance.read_from_db("breakdowns", service_id)
+        breakdown = self.db_instance.read_from_db(
+            MongoCollections.BREAKDOWNS.value, service_id
+        )
         if not breakdown:
             return "Did not find breakdown, cannot remove connection", 404
         breakdown = breakdown[service_id]
@@ -259,7 +261,9 @@ class ConnectionHandler:
             status, code = self._send_breakdown_to_lc(
                 breakdown, "delete", json.loads(connection_request)
             )
-            self.db_instance.delete_one_entry("breakdowns", service_id)
+            self.db_instance.delete_one_entry(
+                MongoCollections.BREAKDOWNS.value, service_id
+            )
             self.archive_connection(service_id)
             logger.debug(f"Breakdown sent to LC, status: {status}, code: {code}")
             return status, code
@@ -342,7 +346,7 @@ def get_connection_status(db, service_id: str):
     assert db is not None
     assert service_id is not None
 
-    breakdown = db.read_from_db("breakdowns", service_id)
+    breakdown = db.read_from_db(MongoCollections.BREAKDOWNS.value, service_id)
     if not breakdown:
         logger.info(f"Could not find breakdown for {service_id}")
         return None

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -4,7 +4,6 @@ import time
 import traceback
 from typing import Tuple
 
-from sdx_controller.utils.constants import MongoCollections, Constants
 from sdx_datamodel.parsing.exceptions import ServiceNotSupportedException
 from sdx_pce.load_balancing.te_solver import TESolver
 from sdx_pce.topology.temanager import TEManager
@@ -12,6 +11,7 @@ from sdx_pce.utils.exceptions import RequestValidationError, TEError
 
 from sdx_controller.messaging.topic_queue_producer import TopicQueueProducer
 from sdx_controller.models.simple_link import SimpleLink
+from sdx_controller.utils.constants import Constants, MongoCollections
 from sdx_controller.utils.parse_helper import ParseHelper
 
 logger = logging.getLogger(__name__)

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -4,7 +4,7 @@ import time
 import traceback
 from typing import Tuple
 
-from sdx_controller.utils.constants import MongoCollections
+from sdx_controller.utils.constants import MongoCollections, Constants
 from sdx_datamodel.parsing.exceptions import ServiceNotSupportedException
 from sdx_pce.load_balancing.te_solver import TESolver
 from sdx_pce.topology.temanager import TEManager
@@ -31,10 +31,10 @@ class ConnectionHandler:
 
         link_connections_dict_json = (
             self.db_instance.read_from_db(
-                MongoCollections.LINKS, "link_connections_dict"
-            )["link_connections_dict"]
+                MongoCollections.LINKS, Constants.LINK_CONNECTIONS_DICT
+            )[Constants.LINK_CONNECTIONS_DICT]
             if self.db_instance.read_from_db(
-                MongoCollections.LINKS, "link_connections_dict"
+                MongoCollections.LINKS, Constants.LINK_CONNECTIONS_DICT
             )
             else None
         )
@@ -71,7 +71,7 @@ class ConnectionHandler:
 
                 self.db_instance.add_key_value_pair_to_db(
                     MongoCollections.LINKS,
-                    "link_connections_dict",
+                    Constants.LINK_CONNECTIONS_DICT,
                     json.dumps(link_connections_dict),
                 )
 
@@ -100,7 +100,7 @@ class ConnectionHandler:
 
                 self.db_instance.add_key_value_pair_to_db(
                     MongoCollections.LINKS,
-                    "link_connections_dict",
+                    Constants.LINK_CONNECTIONS_DICT,
                     json.dumps(link_connections_dict),
                 )
 
@@ -278,18 +278,18 @@ class ConnectionHandler:
     def handle_link_failure(self, te_manager, failed_links):
         logger.debug("Handling connections that contain failed link.")
         link_connections_dict_str = self.db_instance.read_from_db(
-            MongoCollections.LINKS, "link_connections_dict"
+            MongoCollections.LINKS, Constants.LINK_CONNECTIONS_DICT
         )
 
         if (
             not link_connections_dict_str
-            or not link_connections_dict_str["link_connections_dict"]
+            or not link_connections_dict_str[Constants.LINK_CONNECTIONS_DICT]
         ):
             logger.debug("No connection has been placed yet.")
             return
 
         link_connections_dict = json.loads(
-            link_connections_dict_str["link_connections_dict"]
+            link_connections_dict_str[Constants.LINK_CONNECTIONS_DICT]
         )
 
         for link in failed_links:

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -30,10 +30,12 @@ class ConnectionHandler:
             return "Could not break down the solution", 400
 
         link_connections_dict_json = (
-            self.db_instance.read_from_db("links", "link_connections_dict")[
-                "link_connections_dict"
-            ]
-            if self.db_instance.read_from_db("links", "link_connections_dict")
+            self.db_instance.read_from_db(
+                MongoCollections.LINKS.value, "link_connections_dict"
+            )["link_connections_dict"]
+            if self.db_instance.read_from_db(
+                MongoCollections.LINKS.value, "link_connections_dict"
+            )
             else None
         )
 
@@ -68,7 +70,9 @@ class ConnectionHandler:
                     link_connections_dict[simple_link].remove(connection_request)
 
                 self.db_instance.add_key_value_pair_to_db(
-                    "links", "link_connections_dict", json.dumps(link_connections_dict)
+                    MongoCollections.LINKS.value,
+                    "link_connections_dict",
+                    json.dumps(link_connections_dict),
                 )
 
             if interdomain_a:
@@ -95,7 +99,9 @@ class ConnectionHandler:
                     link_connections_dict[simple_link].remove(connection_request)
 
                 self.db_instance.add_key_value_pair_to_db(
-                    "links", "link_connections_dict", json.dumps(link_connections_dict)
+                    MongoCollections.LINKS.value,
+                    "link_connections_dict",
+                    json.dumps(link_connections_dict),
                 )
 
                 interdomain_a = link.get("uni_z", {}).get("port_id")
@@ -219,7 +225,7 @@ class ConnectionHandler:
         )
 
         historical_connections = self.db_instance.read_from_db(
-            "historical_connections", service_id
+            MongoCollections.HISTORICAL_CONNECTIONS.value, service_id
         )
         # Current timestamp in seconds
         timestamp = int(time.time())
@@ -230,11 +236,13 @@ class ConnectionHandler:
                 json.dumps({timestamp: json.loads(connection_request_str)})
             )
             self.db_instance.add_key_value_pair_to_db(
-                "historical_connections", service_id, historical_connections_list
+                MongoCollections.HISTORICAL_CONNECTIONS.value,
+                service_id,
+                historical_connections_list,
             )
         else:
             self.db_instance.add_key_value_pair_to_db(
-                "historical_connections",
+                MongoCollections.HISTORICAL_CONNECTIONS.value,
                 service_id,
                 [json.dumps({timestamp: json.loads(connection_request_str)})],
             )
@@ -272,9 +280,9 @@ class ConnectionHandler:
             return f"Error when removing breakdown: {e}", 400
 
     def handle_link_failure(self, te_manager, failed_links):
-        logger.debug("---Handling connections that contain failed link.---")
+        logger.debug("Handling connections that contain failed link.")
         link_connections_dict_str = self.db_instance.read_from_db(
-            "links", "link_connections_dict"
+            MongoCollections.LINKS.value, "link_connections_dict"
         )
 
         if (
@@ -332,7 +340,7 @@ class ConnectionHandler:
 
     def get_archived_connections(self, service_id: str):
         historical_connections = self.db_instance.read_from_db(
-            "historical_connections", service_id
+            MongoCollections.HISTORICAL_CONNECTIONS.value, service_id
         )
         if not historical_connections:
             return None

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -2,8 +2,8 @@ import json
 import logging
 
 from sdx_controller.handlers.connection_handler import ConnectionHandler
+from sdx_controller.utils.constants import Constants, MongoCollections
 from sdx_controller.utils.parse_helper import ParseHelper
-from sdx_controller.utils.constants import MongoCollections, Constants
 
 logger = logging.getLogger(__name__)
 

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -31,7 +31,9 @@ class LcMessageHandler:
             if not service_id:
                 return
 
-            connection = self.db_instance.read_from_db("connections", service_id)
+            connection = self.db_instance.read_from_db(
+                MongoCollections.CONNECTIONS.value, service_id
+            )
 
             if not connection:
                 return
@@ -47,7 +49,9 @@ class LcMessageHandler:
                 connection_json["status"] = "up"
 
             self.db_instance.add_key_value_pair_to_db(
-                "connections", service_id, json.dumps(connection_json)
+                MongoCollections.CONNECTIONS.value,
+                service_id,
+                json.dumps(connection_json),
             )
             logger.info("Connection updated: " + service_id)
             return

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -3,7 +3,7 @@ import logging
 
 from sdx_controller.handlers.connection_handler import ConnectionHandler
 from sdx_controller.utils.parse_helper import ParseHelper
-from sdx_controller.utils.constants import MongoCollections
+from sdx_controller.utils.constants import MongoCollections, Constants
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class LcMessageHandler:
                 return
 
             connection = self.db_instance.read_from_db(
-                MongoCollections.CONNECTIONS.value, service_id
+                MongoCollections.CONNECTIONS, service_id
             )
 
             if not connection:
@@ -49,7 +49,7 @@ class LcMessageHandler:
                 connection_json["status"] = "up"
 
             self.db_instance.add_key_value_pair_to_db(
-                MongoCollections.CONNECTIONS.value,
+                MongoCollections.CONNECTIONS,
                 service_id,
                 json.dumps(connection_json),
             )
@@ -65,7 +65,7 @@ class LcMessageHandler:
         db_msg_id = str(msg_id) + "-" + str(msg_version)
         # add message to db
         self.db_instance.add_key_value_pair_to_db(
-            MongoCollections.TOPOLOGIES.value, db_msg_id, msg
+            MongoCollections.TOPOLOGIES, db_msg_id, msg
         )
         logger.info("Save to database complete.")
         logger.info("message ID:" + str(db_msg_id))
@@ -86,14 +86,14 @@ class LcMessageHandler:
         else:
             domain_list.append(domain_name)
             self.db_instance.add_key_value_pair_to_db(
-                MongoCollections.DOMAINS.value, "domain_list", domain_list
+                MongoCollections.DOMAINS, Constants.DOMAIN_LIST, domain_list
             )
             logger.info("Adding topology to TE manager")
             self.te_manager.add_topology(msg_json)
 
         logger.info(f"Adding topology {domain_name} to db.")
         self.db_instance.add_key_value_pair_to_db(
-            MongoCollections.TOPOLOGIES.value, domain_name, json.dumps(msg_json)
+            MongoCollections.TOPOLOGIES, domain_name, json.dumps(msg_json)
         )
 
         # TODO: use TEManager API directly; but TEManager does not
@@ -103,6 +103,6 @@ class LcMessageHandler:
         )
         # use 'latest_topo' as PK to save latest topo to db
         self.db_instance.add_key_value_pair_to_db(
-            MongoCollections.TOPOLOGIES.value, "latest_topo", latest_topo
+            MongoCollections.TOPOLOGIES, Constants.LATEST_TOPO, latest_topo
         )
         logger.info("Save to database complete.")

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -3,6 +3,7 @@ import logging
 
 from sdx_controller.handlers.connection_handler import ConnectionHandler
 from sdx_controller.utils.parse_helper import ParseHelper
+from sdx_controller.utils.constants import MongoCollections
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,9 @@ class LcMessageHandler:
 
         db_msg_id = str(msg_id) + "-" + str(msg_version)
         # add message to db
-        self.db_instance.add_key_value_pair_to_db("topologies", db_msg_id, msg)
+        self.db_instance.add_key_value_pair_to_db(
+            MongoCollections.TOPOLOGIES.value, db_msg_id, msg
+        )
         logger.info("Save to database complete.")
         logger.info("message ID:" + str(db_msg_id))
 
@@ -86,7 +89,7 @@ class LcMessageHandler:
 
         logger.info(f"Adding topology {domain_name} to db.")
         self.db_instance.add_key_value_pair_to_db(
-            "topologies", domain_name, json.dumps(msg_json)
+            MongoCollections.TOPOLOGIES.value, domain_name, json.dumps(msg_json)
         )
 
         # TODO: use TEManager API directly; but TEManager does not
@@ -96,6 +99,6 @@ class LcMessageHandler:
         )
         # use 'latest_topo' as PK to save latest topo to db
         self.db_instance.add_key_value_pair_to_db(
-            "topologies", "latest_topo", latest_topo
+            MongoCollections.TOPOLOGIES.value, "latest_topo", latest_topo
         )
         logger.info("Save to database complete.")

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -86,7 +86,7 @@ class LcMessageHandler:
         else:
             domain_list.append(domain_name)
             self.db_instance.add_key_value_pair_to_db(
-                "domains", "domain_list", domain_list
+                MongoCollections.DOMAINS.value, "domain_list", domain_list
             )
             logger.info("Adding topology to TE manager")
             self.te_manager.add_topology(msg_json)

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -93,7 +93,9 @@ class RpcConsumer(object):
         # This part reads from DB when SDX controller initially starts.
         # It looks for domain_list, if already in DB,
         # Then use the existing ones from DB.
-        domain_list_from_db = db_instance.read_from_db("domains", "domain_list")
+        domain_list_from_db = db_instance.read_from_db(
+            MongoCollections.DOMAINS.value, "domain_list"
+        )
         latest_topo_from_db = db_instance.read_from_db(
             MongoCollections.TOPOLOGIES.value, "latest_topo"
         )

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -9,7 +9,7 @@ import pika
 
 from sdx_controller.handlers.lc_message_handler import LcMessageHandler
 from sdx_controller.utils.parse_helper import ParseHelper
-from sdx_controller.utils.constants import MongoCollections
+from sdx_controller.utils.constants import MongoCollections, Constants
 
 MQ_HOST = os.getenv("MQ_HOST")
 MQ_PORT = os.getenv("MQ_PORT") or 5672
@@ -94,28 +94,26 @@ class RpcConsumer(object):
         # It looks for domain_list, if already in DB,
         # Then use the existing ones from DB.
         domain_list_from_db = db_instance.read_from_db(
-            MongoCollections.DOMAINS.value, "domain_list"
+            MongoCollections.DOMAINS, Constants.DOMAIN_LIST
         )
         latest_topo_from_db = db_instance.read_from_db(
-            MongoCollections.TOPOLOGIES.value, "latest_topo"
+            MongoCollections.TOPOLOGIES, Constants.LATEST_TOPO
         )
 
         if domain_list_from_db:
-            domain_list = domain_list_from_db["domain_list"]
+            domain_list = domain_list_from_db[Constants.DOMAIN_LIST]
             logger.debug("Domain list already exists in db: ")
             logger.debug(domain_list)
 
         if latest_topo_from_db:
-            latest_topo = latest_topo_from_db["latest_topo"]
+            latest_topo = latest_topo_from_db[Constants.LATEST_TOPO]
             logger.debug("Topology already exists in db: ")
             logger.debug(latest_topo)
 
         # If topologies already saved in db, use them to initialize te_manager
         if domain_list:
             for domain in domain_list:
-                topology = db_instance.read_from_db(
-                    MongoCollections.TOPOLOGIES.value, domain
-                )
+                topology = db_instance.read_from_db(MongoCollections.TOPOLOGIES, domain)
 
                 if not topology:
                     continue

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -8,8 +8,8 @@ from queue import Queue
 import pika
 
 from sdx_controller.handlers.lc_message_handler import LcMessageHandler
+from sdx_controller.utils.constants import Constants, MongoCollections
 from sdx_controller.utils.parse_helper import ParseHelper
-from sdx_controller.utils.constants import MongoCollections, Constants
 
 MQ_HOST = os.getenv("MQ_HOST")
 MQ_PORT = os.getenv("MQ_PORT") or 5672

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -9,6 +9,7 @@ import pika
 
 from sdx_controller.handlers.lc_message_handler import LcMessageHandler
 from sdx_controller.utils.parse_helper import ParseHelper
+from sdx_controller.utils.constants import MongoCollections
 
 MQ_HOST = os.getenv("MQ_HOST")
 MQ_PORT = os.getenv("MQ_PORT") or 5672
@@ -93,7 +94,9 @@ class RpcConsumer(object):
         # It looks for domain_list, if already in DB,
         # Then use the existing ones from DB.
         domain_list_from_db = db_instance.read_from_db("domains", "domain_list")
-        latest_topo_from_db = db_instance.read_from_db("topologies", "latest_topo")
+        latest_topo_from_db = db_instance.read_from_db(
+            MongoCollections.TOPOLOGIES.value, "latest_topo"
+        )
 
         if domain_list_from_db:
             domain_list = domain_list_from_db["domain_list"]
@@ -108,7 +111,9 @@ class RpcConsumer(object):
         # If topologies already saved in db, use them to initialize te_manager
         if domain_list:
             for domain in domain_list:
-                topology = db_instance.read_from_db("topologies", domain)
+                topology = db_instance.read_from_db(
+                    MongoCollections.TOPOLOGIES.value, domain
+                )
 
                 if not topology:
                     continue

--- a/sdx_controller/test/test_db_utils.py
+++ b/sdx_controller/test/test_db_utils.py
@@ -3,8 +3,8 @@ import unittest
 
 import pymongo
 
-from sdx_controller.utils.db_utils import DbUtils
 from sdx_controller.utils.constants import MongoCollections
+from sdx_controller.utils.db_utils import DbUtils
 
 
 class DbUtilsTests(unittest.TestCase):

--- a/sdx_controller/test/test_db_utils.py
+++ b/sdx_controller/test/test_db_utils.py
@@ -4,6 +4,7 @@ import unittest
 import pymongo
 
 from sdx_controller.utils.db_utils import DbUtils
+from sdx_controller.utils.constants import MongoCollections
 
 
 class DbUtilsTests(unittest.TestCase):
@@ -39,7 +40,7 @@ class DbUtilsTests(unittest.TestCase):
     def test_db_updates(self):
         # Set up the necessary environment variables.
         os.environ["DB_NAME"] = self.env.get("DB_NAME")
-        os.environ["DB_CONFIG_TABLE_NAME"] = "topologies"
+        os.environ["DB_CONFIG_TABLE_NAME"] = MongoCollections.TOPOLOGIES.value
 
         os.environ["MONGO_HOST"] = self.env.get("MONGO_HOST")
         os.environ["MONGO_PORT"] = self.env.get("MONGO_PORT")

--- a/sdx_controller/test/test_db_utils.py
+++ b/sdx_controller/test/test_db_utils.py
@@ -40,7 +40,7 @@ class DbUtilsTests(unittest.TestCase):
     def test_db_updates(self):
         # Set up the necessary environment variables.
         os.environ["DB_NAME"] = self.env.get("DB_NAME")
-        os.environ["DB_CONFIG_TABLE_NAME"] = MongoCollections.TOPOLOGIES.value
+        os.environ["DB_CONFIG_TABLE_NAME"] = MongoCollections.TOPOLOGIES
 
         os.environ["MONGO_HOST"] = self.env.get("MONGO_HOST")
         os.environ["MONGO_PORT"] = self.env.get("MONGO_PORT")

--- a/sdx_controller/utils/constants.py
+++ b/sdx_controller/utils/constants.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class MongoCollections(Enum):
+    TOPOLOGIES = "topologies"
+    CONNECTIONS = "connections"
+    BREAKDOWNS = "breakdowns"
+    DOMAINS = "domains"
+    LINKS = "links"
+    HISTORICAL_CONNECTIONS = "historical_connections"

--- a/sdx_controller/utils/constants.py
+++ b/sdx_controller/utils/constants.py
@@ -1,10 +1,12 @@
-from enum import Enum
-
-
-class MongoCollections(Enum):
+class MongoCollections:
     TOPOLOGIES = "topologies"
     CONNECTIONS = "connections"
     BREAKDOWNS = "breakdowns"
     DOMAINS = "domains"
     LINKS = "links"
     HISTORICAL_CONNECTIONS = "historical_connections"
+
+
+class Constants:
+    DOMAIN_LIST = "domain_list"
+    LATEST_TOPO = "latest_topo"

--- a/sdx_controller/utils/constants.py
+++ b/sdx_controller/utils/constants.py
@@ -10,3 +10,4 @@ class MongoCollections:
 class Constants:
     DOMAIN_LIST = "domain_list"
     LATEST_TOPO = "latest_topo"
+    LINK_CONNECTIONS_DICT = "link_connections_dict"

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -65,7 +65,7 @@ class DbUtils(object):
         # config_col = self.sdxdb[self.config_table_name]
         for collection in MongoCollections:
             if collection not in self.sdxdb.list_collection_names():
-                self.sdxdb.create_collection(collection.value)
+                self.sdxdb.create_collection(collection)
 
         self.logger.debug(f"DB {self.db_name} initialized")
 

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -1,10 +1,10 @@
 import logging
 import os
 from urllib.parse import urlparse
-from sdx_controller.utils.constants import MongoCollections
 
 import pymongo
 
+from sdx_controller.utils.constants import MongoCollections
 
 pymongo_logger = logging.getLogger("pymongo")
 pymongo_logger.setLevel(logging.INFO)

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -1,17 +1,19 @@
 import logging
 import os
 from urllib.parse import urlparse
+from enum import Enum
 
 import pymongo
 
-COLLECTION_NAMES = [
-    "topologies",
-    "connections",
-    "breakdowns",
-    "domains",
-    "links",
-    "historical_connections",
-]
+
+class MongoCollections(Enum):
+    TOPOLOGIES = "topologies"
+    CONNECTIONS = "connections"
+    BREAKDOWNS = "breakdowns"
+    DOMAINS = "domains"
+    LINKS = "links"
+    HISTORICAL_CONNECTIONS = "historical_connections"
+
 
 pymongo_logger = logging.getLogger("pymongo")
 pymongo_logger.setLevel(logging.INFO)
@@ -70,9 +72,9 @@ class DbUtils(object):
 
         self.sdxdb = self.mongo_client[self.db_name]
         # config_col = self.sdxdb[self.config_table_name]
-        for name in COLLECTION_NAMES:
-            if name not in self.sdxdb.list_collection_names():
-                self.sdxdb.create_collection(name)
+        for collection in MongoCollections:
+            if collection not in self.sdxdb.list_collection_names():
+                self.sdxdb.create_collection(collection.value)
 
         self.logger.debug(f"DB {self.db_name} initialized")
 

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -63,8 +63,8 @@ class DbUtils(object):
 
         self.sdxdb = self.mongo_client[self.db_name]
         # config_col = self.sdxdb[self.config_table_name]
-        for collection in MongoCollections:
-            if collection not in self.sdxdb.list_collection_names():
+        for key, collection in MongoCollections.__dict__.items():
+            if not key.startswith("__") and collection not in self.sdxdb.list_collection_names():
                 self.sdxdb.create_collection(collection)
 
         self.logger.debug(f"DB {self.db_name} initialized")

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -1,18 +1,9 @@
 import logging
 import os
 from urllib.parse import urlparse
-from enum import Enum
+from constants import MongoCollections
 
 import pymongo
-
-
-class MongoCollections(Enum):
-    TOPOLOGIES = "topologies"
-    CONNECTIONS = "connections"
-    BREAKDOWNS = "breakdowns"
-    DOMAINS = "domains"
-    LINKS = "links"
-    HISTORICAL_CONNECTIONS = "historical_connections"
 
 
 pymongo_logger = logging.getLogger("pymongo")

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -64,7 +64,10 @@ class DbUtils(object):
         self.sdxdb = self.mongo_client[self.db_name]
         # config_col = self.sdxdb[self.config_table_name]
         for key, collection in MongoCollections.__dict__.items():
-            if not key.startswith("__") and collection not in self.sdxdb.list_collection_names():
+            if (
+                not key.startswith("__")
+                and collection not in self.sdxdb.list_collection_names()
+            ):
                 self.sdxdb.create_collection(collection)
 
         self.logger.debug(f"DB {self.db_name} initialized")

--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from urllib.parse import urlparse
-from constants import MongoCollections
+from sdx_controller.utils.constants import MongoCollections
 
 import pymongo
 


### PR DESCRIPTION
Use constants instead of hardcoded strings for table names, etc.

This PR does not touch MQ related consts, because they were set by env var.