### PR TITLE
Change link to dict access

### DIFF
--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -306,12 +306,12 @@ class ConnectionHandler:
         )
 
         for link in failed_links:
-            logger.info(f"Handling link failure on {link.id}")
+            logger.info(f"Handling link failure on {link['id']}")
             port_list = []
-            if not link.ports:
+            if "ports" not in link:
                 continue
-            for port in link.ports:
-                port_id = port if isinstance(port, str) else port.id
+            for port in link["ports"]:
+                port_id = port if isinstance(port, str) else port.get("id")
                 if not port_id:
                     continue
                 port_list.append(port_id)
@@ -323,7 +323,7 @@ class ConnectionHandler:
                 connections = link_connections_dict[simple_link]
                 for index, connection in enumerate(connections):
                     logger.info(
-                        f"Connection {connection['id']} affected by link {link.id}"
+                        f"Connection {connection['id']} affected by link {link['id']}"
                     )
                     if "id" not in connection:
                         continue


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/424

Link here is actually a dict, not object. This PR changes link access back to dict access, partially reversing changes in https://github.com/atlanticwave-sdx/sdx-controller/pull/419