### PR TITLE
Fix inconsistent Link to Service IDs mapping

### DIFF
--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -37,20 +37,13 @@ class ConnectionHandler:
         if breakdown is None:
             return "Could not break down the solution", 400
 
-        link_connections_dict_json = (
-            self.db_instance.read_from_db(
-                MongoCollections.LINKS, Constants.LINK_CONNECTIONS_DICT
-            )[Constants.LINK_CONNECTIONS_DICT]
-            if self.db_instance.read_from_db(
-                MongoCollections.LINKS, Constants.LINK_CONNECTIONS_DICT
-            )
-            else None
+        link_connections_dict_json = self.db_instance.read_from_db(
+            MongoCollections.LINKS, Constants.LINK_CONNECTIONS_DICT
         )
 
-        if link_connections_dict_json:
-            link_connections_dict = json.loads(link_connections_dict_json)
-        else:
-            link_connections_dict = {}
+        link_connections_dict = json.loads(
+            link_connections_dict_json[Constants.LINK_CONNECTIONS_DICT]
+        ) if link_connections_dict_json else {}
 
         interdomain_a, interdomain_b = None, None
         connection_service_id = connection_request.get("id")
@@ -70,22 +63,16 @@ class ConnectionHandler:
                 if (
                     operation == "post"
                     and connection_service_id
-                    and connection_request not in link_connections_dict[simple_link]
+                    and connection_service_id not in link_connections_dict[simple_link]
                 ):
                     link_connections_dict[simple_link].append(connection_service_id)
 
                 if (
                     operation == "delete"
                     and connection_service_id
-                    and connection_request in link_connections_dict[simple_link]
+                    and connection_service_id in link_connections_dict[simple_link]
                 ):
                     link_connections_dict[simple_link].remove(connection_service_id)
-
-                self.db_instance.add_key_value_pair_to_db(
-                    MongoCollections.LINKS,
-                    Constants.LINK_CONNECTIONS_DICT,
-                    json.dumps(link_connections_dict),
-                )
 
             if interdomain_a:
                 interdomain_b = link.get("uni_a", {}).get("port_id")
@@ -101,24 +88,24 @@ class ConnectionHandler:
                 if (
                     operation == "post"
                     and connection_service_id
-                    and connection_request not in link_connections_dict[simple_link]
+                    and connection_service_id not in link_connections_dict[simple_link]
                 ):
                     link_connections_dict[simple_link].append(connection_service_id)
 
                 if (
                     operation == "delete"
                     and connection_service_id
-                    and connection_request in link_connections_dict[simple_link]
+                    and connection_service_id in link_connections_dict[simple_link]
                 ):
                     link_connections_dict[simple_link].remove(connection_service_id)
 
-                self.db_instance.add_key_value_pair_to_db(
-                    MongoCollections.LINKS,
-                    Constants.LINK_CONNECTIONS_DICT,
-                    json.dumps(link_connections_dict),
-                )
-
                 interdomain_a = link.get("uni_z", {}).get("port_id")
+
+            self.db_instance.add_key_value_pair_to_db(
+                MongoCollections.LINKS,
+                Constants.LINK_CONNECTIONS_DICT,
+                json.dumps(link_connections_dict),
+            )
 
             logger.debug(f"Attempting to publish domain: {domain}, link: {link}")
 

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -41,9 +41,11 @@ class ConnectionHandler:
             MongoCollections.LINKS, Constants.LINK_CONNECTIONS_DICT
         )
 
-        link_connections_dict = json.loads(
-            link_connections_dict_json[Constants.LINK_CONNECTIONS_DICT]
-        ) if link_connections_dict_json else {}
+        link_connections_dict = (
+            json.loads(link_connections_dict_json[Constants.LINK_CONNECTIONS_DICT])
+            if link_connections_dict_json
+            else {}
+        )
 
         interdomain_a, interdomain_b = None, None
         connection_service_id = connection_request.get("id")

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -502,6 +502,7 @@ def get_connection_status(db, service_id: str):
     # request for this service_id.
     name = "unknown"
     description = "unknown"
+    status = "unknown"
     qos_metrics = {}
     scheduling = {}
     notifications = {}
@@ -523,6 +524,7 @@ def get_connection_status(db, service_id: str):
         request_dict = json.loads(request.get(service_id))
         name = request_dict.get("name")
         description = request_dict.get("description")
+        status = request_dict.get("status")
         qos_metrics = request_dict.get("qos_metrics")
         scheduling = request_dict.get("scheduling")
         notifications = request_dict.get("notifications")
@@ -606,6 +608,7 @@ def get_connection_status(db, service_id: str):
         "service_id": service_id,
         "name": name,
         "description": description,
+        "status": status,
         "endpoints": response_endpoints,
         "current_path": endpoints,
         "archived_date": 0,


### PR DESCRIPTION
Fix #436 

### Description of the change

This PR is an enhancement over PR #433 to correctly keep track of Services using certain links throughout link failures and updates.

I've also took the opportunity to refactor a little bit calls to MongoDB and add some performance improvements by removing unnecessary extra queries.

### Local tests

After applying the changes proposed here, the inconsistencies are not present anymore:

- Before link failure:
```
$ ./show-sdx-controller.sh l2vpn ec156ec1-cd4b-401b-a526-b77910b38a9e
ID                                    ENDPOINT-1                          VLAN-1  ENDPOINT-2                     VLAN-2
--                                    ----------                          ------  ----------                     ------
ec156ec1-cd4b-401b-a526-b77910b38a9e  urn:sdx:port:ampath.net:Ampath3:50  302     urn:sdx:port:sax.net:Sax02:50  4000

Current Path:
-------------
urn:sdx:port:ampath.net:Ampath3:50  302
urn:sdx:port:ampath.net:Ampath2:40  1
urn:sdx:port:sax.net:Sax02:40       1
urn:sdx:port:sax.net:Sax02:50       4000

$ docker compose exec -it mongo1t mongosh "mongodb://192.168.0.6:27027/sdx_controller_db?directConnection=true&authSource=admin" --eval "db.links.find({})"
[
  {
    _id: ObjectId('67ed4f623d882a5bbfda32c3'),
    link_connections_dict: '{"urn:sdx:port:ampath.net:Ampath2:40,urn:sdx:port:ampath.net:Ampath3:50": ["ec156ec1-cd4b-401b-a526-b77910b38a9e"], "urn:sdx:port:sax.net:Sax02:40,urn:sdx:port:sax.net:Sax02:50": ["ec156ec1-cd4b-401b-a526-b77910b38a9e"], "urn:sdx:port:ampath.net:Ampath2:40,urn:sdx:port:sax.net:Sax02:40": ["ec156ec1-cd4b-401b-a526-b77910b38a9e"]}'
  }
]
```

- After link failure:
```
$ ./show-sdx-controller.sh l2vpn ec156ec1-cd4b-401b-a526-b77910b38a9e
ID                                    ENDPOINT-1                          VLAN-1  ENDPOINT-2                     VLAN-2
--                                    ----------                          ------  ----------                     ------
ec156ec1-cd4b-401b-a526-b77910b38a9e  urn:sdx:port:ampath.net:Ampath3:50  302     urn:sdx:port:sax.net:Sax02:50  4000

Current Path:
-------------
urn:sdx:port:ampath.net:Ampath3:50  302
urn:sdx:port:ampath.net:Ampath1:40  1
urn:sdx:port:sax.net:Sax01:40       1
urn:sdx:port:sax.net:Sax02:50       4000

$ docker compose exec -it mongo1t mongosh "mongodb://192.168.0.6:27027/sdx_controller_db?directConnection=true&authSource=admin" --eval "db.links.find({})"
[
  {
    _id: ObjectId('67ed4f623d882a5bbfda32c3'),
    link_connections_dict: '{"urn:sdx:port:ampath.net:Ampath2:40,urn:sdx:port:ampath.net:Ampath3:50": [], "urn:sdx:port:sax.net:Sax02:40,urn:sdx:port:sax.net:Sax02:50": [], "urn:sdx:port:ampath.net:Ampath2:40,urn:sdx:port:sax.net:Sax02:40": [], "urn:sdx:port:ampath.net:Ampath1:40,urn:sdx:port:ampath.net:Ampath3:50": ["ec156ec1-cd4b-401b-a526-b77910b38a9e"], "urn:sdx:port:sax.net:Sax01:40,urn:sdx:port:sax.net:Sax02:50": ["ec156ec1-cd4b-401b-a526-b77910b38a9e"], "urn:sdx:port:ampath.net:Ampath1:40,urn:sdx:port:sax.net:Sax01:40": ["ec156ec1-cd4b-401b-a526-b77910b38a9e"]}'
  }
]
```