### PR TITLE
Enhance l2vpn body persistency to avoid inconsistent value for oxp_success_count

### DIFF
--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -170,7 +170,7 @@ def place_connection(body):
     body = json.loads(value[service_id]) if value else body
 
     if code // 100 != 2:
-        body, _ = connection_state_machine(body, ConnectionStateMachine.State.REJECTED)
+        body["status"] = str(ConnectionStateMachine.State.REJECTED)
 
     db_instance.add_key_value_pair_to_db(
         MongoCollections.CONNECTIONS, service_id, json.dumps(body)

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -218,20 +218,23 @@ def patch_connection(service_id, body=None):  # noqa: E501
     if not connexion.request.is_json:
         return "Request body must be JSON", 400
 
-    body = L2vpnServiceIdBody.from_dict(connexion.request.get_json())  # noqa: E501
+    new_body = connexion.request.get_json()
 
-    logger.info(f"Gathered connexion JSON: {body}")
+    logger.info(f"Gathered connexion JSON: {new_body}")
 
-    body["id"] = service_id
-    logger.info(f"Request has no ID. Generated ID: {service_id}")
+    body = json.loads(value[service_id])
+    body.update(new_body)
 
     body, _ = connection_state_machine(body, ConnectionStateMachine.State.MODIFYING)
+    body["oxp_success_count"] = 0
+    db_instance.add_key_value_pair_to_db(
+        MongoCollections.CONNECTIONS, service_id, json.dumps(body)
+    )
+
     try:
         logger.info("Removing connection")
         # Get roll back connection before removing connection
-        rollback_conn_body = db_instance.read_from_db(
-            MongoCollections.CONNECTIONS, service_id
-        )
+        rollback_conn_body = value
         remove_conn_reason, remove_conn_code = connection_handler.remove_connection(
             current_app.te_manager, service_id
         )
@@ -253,18 +256,18 @@ def patch_connection(service_id, body=None):  # noqa: E501
         f"Placing new connection {service_id} with te_manager: {current_app.te_manager}"
     )
 
+    body, _ = connection_state_machine(
+        body, ConnectionStateMachine.State.UNDER_PROVISIONING
+    )
+    db_instance.add_key_value_pair_to_db(
+        MongoCollections.CONNECTIONS, service_id, json.dumps(body)
+    )
     reason, code = connection_handler.place_connection(current_app.te_manager, body)
 
     if code // 100 == 2:
-        db_instance.add_key_value_pair_to_db(
-            MongoCollections.CONNECTIONS, service_id, json.dumps(body)
-        )
         # Service created successfully
         code = 201
         logger.info(f"Placed: ID: {service_id} reason='{reason}', code={code}")
-        body, _ = connection_state_machine(
-            body, ConnectionStateMachine.State.UNDER_PROVISIONING
-        )
         response = {
             "service_id": service_id,
             "status": body["status"],

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -408,7 +408,9 @@ class ConnectionHandler:
                             connection, ConnectionStateMachine.State.ERROR
                         )
                         self.db_instance.add_key_value_pair_to_db(
-                            MongoCollections.CONNECTIONS, service_id, json.dumps(connection)
+                            MongoCollections.CONNECTIONS,
+                            service_id,
+                            json.dumps(connection),
                         )
 
                     logger.info(

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -399,18 +399,16 @@ class ConnectionHandler:
                     connection, _ = connection_state_machine(
                         connection, ConnectionStateMachine.State.RECOVERING
                     )
+                    connection["oxp_success_count"] = 0
+                    self.db_instance.add_key_value_pair_to_db(
+                        MongoCollections.CONNECTIONS, service_id, json.dumps(connection)
+                    )
                     _reason, code = self.place_connection(te_manager, connection)
                     if code // 100 != 2:
                         connection, _ = connection_state_machine(
                             connection, ConnectionStateMachine.State.ERROR
                         )
 
-                    # count the oxp success response
-                    connection["oxp_success_count"] = 0
-
-                    self.db_instance.add_key_value_pair_to_db(
-                        MongoCollections.CONNECTIONS, service_id, json.dumps(connection)
-                    )
                     logger.info(
                         f"place_connection result: ID: {service_id} reason='{_reason}', code={code}"
                     )

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -393,7 +393,6 @@ class ConnectionHandler:
                         )
                         continue
 
-                    del link_connections_dict[simple_link][index]
                     logger.debug("Removed connection:")
                     logger.debug(connection)
                     connection, _ = connection_state_machine(

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -407,6 +407,9 @@ class ConnectionHandler:
                         connection, _ = connection_state_machine(
                             connection, ConnectionStateMachine.State.ERROR
                         )
+                        self.db_instance.add_key_value_pair_to_db(
+                            MongoCollections.CONNECTIONS, service_id, json.dumps(connection)
+                        )
 
                     logger.info(
                         f"place_connection result: ID: {service_id} reason='{_reason}', code={code}"

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -65,12 +65,13 @@ class LcMessageHandler:
             connection_json["oxp_response"] = oxp_response
 
             if oxp_response_code // 100 == 2:
-                oxp_success_count += 1
-                connection_json["oxp_success_count"] = oxp_success_count
-                if oxp_success_count == oxp_number:
-                    connection_json, _ = connection_state_machine(
-                        connection_json, ConnectionStateMachine.State.UP
-                    )
+                if msg_json.get("operation") != "delete":
+                    oxp_success_count += 1
+                    connection_json["oxp_success_count"] = oxp_success_count
+                    if oxp_success_count == oxp_number:
+                        connection_json, _ = connection_state_machine(
+                            connection_json, ConnectionStateMachine.State.UP
+                        )
             else:
                 if connection_json.get("status") and (
                     connection_json.get("status")


### PR DESCRIPTION
Fix #438 
Fix #441 

Heads-up: this PR sits on top of PR #439 

Heads-up 2: for full benefit from this PR's change, it has to be coordinated with https://github.com/atlanticwave-sdx/sdx-lc/pull/189

### Description of the change

This PR adds some slightly improvements to L2VPN body persistency to avoid inconsistent value for oxp_success_count. Basically, the L2VPN is saved before sending the data to LC and also read from DB after new updates.

Additionally, we fix an error of Array Mutation while Looping over it, which may ended up leaving L2VPN unhandled during Link Failure procedures.

It is important to emphasize that this can still be subject to race conditions as observed on #435 

### Local tests

After applying this PR I executed a few tests creating and removing L2VPN multiple times, as well as simulating multiple link failures. All tests worked as expected and no surprises were reported:

1. Creating multiple L2VPNs
```
$ cat /tmp/ports
urn:sdx:port:ampath.net:Ampath3:50
urn:sdx:port:ampath.net:Ampath2:50
urn:sdx:port:ampath.net:Ampath1:50
urn:sdx:port:sax.net:Sax01:50
urn:sdx:port:sax.net:Sax02:50
urn:sdx:port:tenet.ac.za:Tenet02:50
urn:sdx:port:tenet.ac.za:Tenet03:50
urn:sdx:port:tenet.ac.za:Tenet01:50
vlan=400; echo -n "" > /tmp/seen; for port1 in $(cat /tmp/ports); do for port2 in $(cat /tmp/ports); do if [ $port1 = $port2 ] || grep -q $port2 /tmp/seen; then continue; fi; echo $port1 $port2; curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN '$vlan'", "endpoints": [{"port_id": "'$port1'", "vlan": "'$vlan'"}, {"port_id": "'$port2'", "vlan": "'$vlan'"}]}'; vlan=$(($vlan+1)); done; echo $port1 >> /tmp/seen; done
```

2. Checking the status of the L2VPNs, right after creation:
```
$ docker compose exec -it mongo1t mongosh "mongodb://192.168.0.6:27027/sdx_controller_db?directConnection=true&authSource=admin" --eval "config.set('displayBatchSize', 2000); db.connections.find({})"
[
  {
    _id: ObjectId('67ee91521354100e5dcc28ed'),
    '6a692b3e-d8c3-4241-b39f-5e462bdd2d9b': '{"name": "VLAN 400", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "400"}, {"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "400"}], "id": "6a692b3e-d8c3-4241-b39f-5e462bdd2d9b", "status": "UP", "oxp_success_count": 1, "oxp_response": {"ampath.net": [200, {"circuit_id": "11a2acff3ff745", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91521354100e5dcc28f3'),
    '25a3ceef-ec01-46c3-a2c8-cc03ad42966e': '{"name": "VLAN 401", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "401"}, {"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "401"}], "id": "25a3ceef-ec01-46c3-a2c8-cc03ad42966e", "status": "UP", "oxp_success_count": 1, "oxp_response": {"ampath.net": [200, {"circuit_id": "ba5e91b7d3644a", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91531354100e5dcc28f8'),
    '5d8289dd-aecf-4d78-bfa3-5d26f332cd28': '{"name": "VLAN 402", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "402"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "402"}], "id": "5d8289dd-aecf-4d78-bfa3-5d26f332cd28", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "24d57f51e6af44", "deployed": true}], "ampath.net": [200, {"circuit_id": "afe98cf6ba8d48", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91541354100e5dcc28fd'),
    '05e5eb19-fce2-4b20-b418-5fc8feb79de5': '{"name": "VLAN 403", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "403"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "403"}], "id": "05e5eb19-fce2-4b20-b418-5fc8feb79de5", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "3ec4b1a0263a4d", "deployed": true}], "ampath.net": [200, {"circuit_id": "f1389ac660be48", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91541354100e5dcc2902'),
    '26e1a894-f3c7-4d1c-859c-54d34b6d9e44': '{"name": "VLAN 404", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "404"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "404"}], "id": "26e1a894-f3c7-4d1c-859c-54d34b6d9e44", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "eda4f205abd547", "deployed": true}], "sax.net": [200, {"circuit_id": "858961e9f2a545", "deployed": true}], "ampath.net": [200, {"circuit_id": "bef446275bdc44", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91551354100e5dcc2907'),
    '2e2060a1-6d8c-44b2-9dc9-c7762d0c052b': '{"name": "VLAN 405", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "405"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "405"}], "id": "2e2060a1-6d8c-44b2-9dc9-c7762d0c052b", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "a8ee42fe382b44", "deployed": true}], "sax.net": [200, {"circuit_id": "4d36bdabc0d249", "deployed": true}], "ampath.net": [200, {"circuit_id": "378536fb52f549", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91561354100e5dcc290c'),
    'febc8a1b-0376-4f5f-a034-e9addf1a55ca': '{"name": "VLAN 406", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "406"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "406"}], "id": "febc8a1b-0376-4f5f-a034-e9addf1a55ca", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "c7e9d82aea994d", "deployed": true}], "sax.net": [200, {"circuit_id": "128a53f5b8ac46", "deployed": true}], "ampath.net": [200, {"circuit_id": "3f29d458d6a447", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91571354100e5dcc2911'),
    'ddc37709-9a91-4c20-9f88-963b0967f47e': '{"name": "VLAN 407", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "407"}, {"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "407"}], "id": "ddc37709-9a91-4c20-9f88-963b0967f47e", "status": "UP", "oxp_success_count": 1, "oxp_response": {"ampath.net": [200, {"circuit_id": "f56ce38935de46", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91581354100e5dcc2916'),
    '7f0ef481-8ac6-41f0-9aad-4e4c7f440e08': '{"name": "VLAN 408", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "408"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "408"}], "id": "7f0ef481-8ac6-41f0-9aad-4e4c7f440e08", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "b98a0d817c4d4d", "deployed": true}], "ampath.net": [200, {"circuit_id": "661ab1165d7246", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91591354100e5dcc291b'),
    '4a050ea8-5745-461e-a929-7137c4aaff40': '{"name": "VLAN 409", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "409"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "409"}], "id": "4a050ea8-5745-461e-a929-7137c4aaff40", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "2783f5e0a4714e", "deployed": true}], "ampath.net": [200, {"circuit_id": "2107e0e56c7541", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91591354100e5dcc2920'),
    '0e0b376e-a7cb-44be-8ef3-ef779a516fd9': '{"name": "VLAN 410", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "410"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "410"}], "id": "0e0b376e-a7cb-44be-8ef3-ef779a516fd9", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "0238661a6d7649", "deployed": true}], "sax.net": [200, {"circuit_id": "b8e2a827be2948", "deployed": true}], "ampath.net": [200, {"circuit_id": "a95f0c85f5d246", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915a1354100e5dcc2925'),
    '676b2557-95a3-429c-8d3f-ae0e5a691e2a': '{"name": "VLAN 411", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "411"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "411"}], "id": "676b2557-95a3-429c-8d3f-ae0e5a691e2a", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "be953b6613b946", "deployed": true}], "sax.net": [200, {"circuit_id": "083cec07826145", "deployed": true}], "ampath.net": [200, {"circuit_id": "1ff94009b7334d", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915b1354100e5dcc292a'),
    'da6f70a6-fc11-497b-9ff1-a234805be1e7': '{"name": "VLAN 412", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "412"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "412"}], "id": "da6f70a6-fc11-497b-9ff1-a234805be1e7", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "c872f31f37fe4e", "deployed": true}], "sax.net": [200, {"circuit_id": "97414f3751f04f", "deployed": true}], "ampath.net": [200, {"circuit_id": "0bddb3a2964645", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915c1354100e5dcc292f'),
    'b9e69344-aa7b-4b69-bfe8-182914ef8549': '{"name": "VLAN 413", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "413"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "413"}], "id": "b9e69344-aa7b-4b69-bfe8-182914ef8549", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "3d6a20ebc2094d", "deployed": true}], "ampath.net": [200, {"circuit_id": "33f1dd47cdc44b", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915d1354100e5dcc2934'),
    'cf9ef53a-b6c8-42f4-a61d-87dfc3c8371b': '{"name": "VLAN 414", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "414"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "414"}], "id": "cf9ef53a-b6c8-42f4-a61d-87dfc3c8371b", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "5f66e748fe4741", "deployed": true}], "ampath.net": [200, {"circuit_id": "0f3fc073f54349", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915d1354100e5dcc2939'),
    '74ec52af-8d07-4c93-a92b-897a6e79db6c': '{"name": "VLAN 415", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "415"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "415"}], "id": "74ec52af-8d07-4c93-a92b-897a6e79db6c", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "982dedb6fc0f42", "deployed": true}], "sax.net": [200, {"circuit_id": "02cb2c1b4a864d", "deployed": true}], "ampath.net": [200, {"circuit_id": "c84436bbb41c42", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915f1354100e5dcc293e'),
    '53b6263c-0bfb-414d-8a93-9423c36f201d': '{"name": "VLAN 416", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "416"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "416"}], "id": "53b6263c-0bfb-414d-8a93-9423c36f201d", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "a49e0840702343", "deployed": true}], "sax.net": [200, {"circuit_id": "f9061db932394d", "deployed": true}], "ampath.net": [200, {"circuit_id": "958dde1da83941", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91601354100e5dcc2943'),
    'f1fdc383-0852-4302-a4f4-0e07fbf980f1': '{"name": "VLAN 417", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "417"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "417"}], "id": "f1fdc383-0852-4302-a4f4-0e07fbf980f1", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "d0e489b4a8a34b", "deployed": true}], "sax.net": [200, {"circuit_id": "2dbbcff7db024d", "deployed": true}], "ampath.net": [200, {"circuit_id": "f1866036822349", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91601354100e5dcc2948'),
    'c9206388-877d-4b34-8c6a-f8f91df71705': '{"name": "VLAN 418", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "418"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "418"}], "id": "c9206388-877d-4b34-8c6a-f8f91df71705", "status": "UP", "oxp_success_count": 1, "oxp_response": {"sax.net": [200, {"circuit_id": "ee5a22af1a1f4d", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91611354100e5dcc294d'),
    'ff5c0bda-7b9d-47a3-8486-ed67cf6b4eba': '{"name": "VLAN 419", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "419"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "419"}], "id": "ff5c0bda-7b9d-47a3-8486-ed67cf6b4eba", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "27fdc8dec6b547", "deployed": true}], "sax.net": [200, {"circuit_id": "9dea6c749c664a", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91621354100e5dcc2952'),
    '5c614b85-e4d9-43fa-913d-03d2f586bd77': '{"name": "VLAN 420", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "420"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "420"}], "id": "5c614b85-e4d9-43fa-913d-03d2f586bd77", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "ee8a0826eee14d", "deployed": true}], "sax.net": [200, {"circuit_id": "31b08cea4c544c", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91631354100e5dcc2957'),
    '5e43a337-1bda-4551-b289-832e8cb53a94': '{"name": "VLAN 421", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "421"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "421"}], "id": "5e43a337-1bda-4551-b289-832e8cb53a94", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "88fa5b5d20064c", "deployed": true}], "sax.net": [200, {"circuit_id": "f033cb2a6fc346", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91641354100e5dcc295c'),
    'b0422904-3c96-4aee-b623-90ff6d476fe5': '{"name": "VLAN 422", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "422"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "422"}], "id": "b0422904-3c96-4aee-b623-90ff6d476fe5", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "9689616cae494b", "deployed": true}], "sax.net": [200, {"circuit_id": "245385c4380f4f", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91651354100e5dcc2961'),
    '2d6348ca-1a0b-4d85-9c72-7caaa4bc01bb': '{"name": "VLAN 423", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "423"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "423"}], "id": "2d6348ca-1a0b-4d85-9c72-7caaa4bc01bb", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "0bce0016c1704f", "deployed": true}], "sax.net": [200, {"circuit_id": "ad39a263686c4d", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91671354100e5dcc2966'),
    'f680a85a-0e26-4225-95d9-ccbeebf293de': '{"name": "VLAN 424", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "424"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "424"}], "id": "f680a85a-0e26-4225-95d9-ccbeebf293de", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "f92a3540c1fa40", "deployed": true}], "sax.net": [200, {"circuit_id": "76aeb612519c49", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91681354100e5dcc296b'),
    '162f2616-6cb6-48fa-a7e1-0e2b79e91ac1': '{"name": "VLAN 425", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "425"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "425"}], "id": "162f2616-6cb6-48fa-a7e1-0e2b79e91ac1", "status": "UP", "oxp_success_count": 1, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "fe9dbdbf995f4b", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91691354100e5dcc2970'),
    'd8c4e636-7273-4c42-b9c3-518fe6015b5b': '{"name": "VLAN 426", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "426"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "426"}], "id": "d8c4e636-7273-4c42-b9c3-518fe6015b5b", "status": "UP", "oxp_success_count": 1, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "357f021bd19342", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee916a1354100e5dcc2975'),
    '030c5a16-f68f-4c38-b61d-28a324bc9e31': '{"name": "VLAN 427", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "427"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "427"}], "id": "030c5a16-f68f-4c38-b61d-28a324bc9e31", "status": "UP", "oxp_success_count": 1, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "946cc4b2364844", "deployed": true}]}}'
  }
]
```

3. Testing connectivity before any link event:
```
$ curl -s http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0  | jq -r '.[]|.service_id' | while read ID; do echo $ID; ./test-l2vpn-v2.sh $ID; done
030c5a16-f68f-4c38-b61d-28a324bc9e31
Configuring hostA (h8)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 111 ping6 -c5 -i0.2 2001:db8:427:427::2'
PING 2001:db8:427:427::2(2001:db8:427:427::2) 56 data bytes
64 bytes from 2001:db8:427:427::2: icmp_seq=1 ttl=64 time=0.132 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=2 ttl=64 time=0.074 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=3 ttl=64 time=0.051 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=4 ttl=64 time=0.064 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=5 ttl=64 time=0.053 ms

--- 2001:db8:427:427::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 812ms
rtt min/avg/max/mdev = 0.051/0.074/0.132/0.029 ms
05e5eb19-fce2-4b20-b418-5fc8feb79de5
Configuring hostA (h3)...
Configuring hostZ (h5)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:403:403::2'
PING 2001:db8:403:403::2(2001:db8:403:403::2) 56 data bytes
64 bytes from 2001:db8:403:403::2: icmp_seq=1 ttl=64 time=0.090 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=2 ttl=64 time=0.059 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=3 ttl=64 time=0.059 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=4 ttl=64 time=0.054 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=5 ttl=64 time=0.049 ms

--- 2001:db8:403:403::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.049/0.062/0.090/0.014 ms
0e0b376e-a7cb-44be-8ef3-ef779a516fd9
Configuring hostA (h2)...
Configuring hostZ (h7)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6 -c5 -i0.2 2001:db8:410:410::2'
PING 2001:db8:410:410::2(2001:db8:410:410::2) 56 data bytes
64 bytes from 2001:db8:410:410::2: icmp_seq=1 ttl=64 time=0.132 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=2 ttl=64 time=0.069 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=3 ttl=64 time=0.062 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=4 ttl=64 time=0.060 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=5 ttl=64 time=0.059 ms

--- 2001:db8:410:410::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 816ms
rtt min/avg/max/mdev = 0.059/0.076/0.132/0.028 ms
162f2616-6cb6-48fa-a7e1-0e2b79e91ac1
Configuring hostA (h7)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 109 ping6 -c5 -i0.2 2001:db8:425:425::2'
PING 2001:db8:425:425::2(2001:db8:425:425::2) 56 data bytes
64 bytes from 2001:db8:425:425::2: icmp_seq=1 ttl=64 time=0.154 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=2 ttl=64 time=0.061 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=3 ttl=64 time=0.057 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=4 ttl=64 time=0.055 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=5 ttl=64 time=0.067 ms

--- 2001:db8:425:425::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.055/0.078/0.154/0.037 ms
25a3ceef-ec01-46c3-a2c8-cc03ad42966e
Configuring hostA (h3)...
Configuring hostZ (h1)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:401:401::2'
PING 2001:db8:401:401::2(2001:db8:401:401::2) 56 data bytes
64 bytes from 2001:db8:401:401::2: icmp_seq=1 ttl=64 time=0.097 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=2 ttl=64 time=0.070 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=3 ttl=64 time=0.057 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=4 ttl=64 time=0.054 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=5 ttl=64 time=0.054 ms

--- 2001:db8:401:401::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.054/0.066/0.097/0.016 ms
26e1a894-f3c7-4d1c-859c-54d34b6d9e44
Configuring hostA (h3)...
Configuring hostZ (h7)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:404:404::2'
PING 2001:db8:404:404::2(2001:db8:404:404::2) 56 data bytes
64 bytes from 2001:db8:404:404::2: icmp_seq=1 ttl=64 time=0.172 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=2 ttl=64 time=0.065 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=3 ttl=64 time=0.066 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=4 ttl=64 time=0.103 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=5 ttl=64 time=0.096 ms

--- 2001:db8:404:404::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.065/0.100/0.172/0.038 ms
2d6348ca-1a0b-4d85-9c72-7caaa4bc01bb
Configuring hostA (h5)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6 -c5 -i0.2 2001:db8:423:423::2'
PING 2001:db8:423:423::2(2001:db8:423:423::2) 56 data bytes
64 bytes from 2001:db8:423:423::2: icmp_seq=1 ttl=64 time=0.216 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=2 ttl=64 time=0.063 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=3 ttl=64 time=0.060 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=4 ttl=64 time=0.067 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=5 ttl=64 time=0.063 ms

--- 2001:db8:423:423::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.060/0.093/0.216/0.061 ms
2e2060a1-6d8c-44b2-9dc9-c7762d0c052b
Configuring hostA (h3)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:405:405::2'
PING 2001:db8:405:405::2(2001:db8:405:405::2) 56 data bytes
64 bytes from 2001:db8:405:405::2: icmp_seq=1 ttl=64 time=0.108 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=2 ttl=64 time=0.093 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=3 ttl=64 time=0.074 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=4 ttl=64 time=0.069 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=5 ttl=64 time=0.063 ms

--- 2001:db8:405:405::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.063/0.081/0.108/0.016 ms
4a050ea8-5745-461e-a929-7137c4aaff40
Configuring hostA (h2)...
Configuring hostZ (h5)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6 -c5 -i0.2 2001:db8:409:409::2'
PING 2001:db8:409:409::2(2001:db8:409:409::2) 56 data bytes
64 bytes from 2001:db8:409:409::2: icmp_seq=1 ttl=64 time=0.159 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=2 ttl=64 time=0.073 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=3 ttl=64 time=0.051 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=4 ttl=64 time=0.049 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=5 ttl=64 time=0.051 ms

--- 2001:db8:409:409::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.049/0.076/0.159/0.042 ms
53b6263c-0bfb-414d-8a93-9423c36f201d
Configuring hostA (h1)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6 -c5 -i0.2 2001:db8:416:416::2'
PING 2001:db8:416:416::2(2001:db8:416:416::2) 56 data bytes
64 bytes from 2001:db8:416:416::2: icmp_seq=1 ttl=64 time=0.125 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=2 ttl=64 time=0.122 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=3 ttl=64 time=0.111 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=4 ttl=64 time=0.100 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=5 ttl=64 time=0.060 ms

--- 2001:db8:416:416::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 812ms
rtt min/avg/max/mdev = 0.060/0.103/0.125/0.023 ms
5c614b85-e4d9-43fa-913d-03d2f586bd77
Configuring hostA (h4)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6 -c5 -i0.2 2001:db8:420:420::2'
PING 2001:db8:420:420::2(2001:db8:420:420::2) 56 data bytes
64 bytes from 2001:db8:420:420::2: icmp_seq=1 ttl=64 time=0.090 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=2 ttl=64 time=0.063 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=3 ttl=64 time=0.059 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=4 ttl=64 time=0.067 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=5 ttl=64 time=0.084 ms

--- 2001:db8:420:420::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 819ms
rtt min/avg/max/mdev = 0.059/0.072/0.090/0.012 ms
5d8289dd-aecf-4d78-bfa3-5d26f332cd28
Configuring hostA (h3)...
Configuring hostZ (h4)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:402:402::2'
PING 2001:db8:402:402::2(2001:db8:402:402::2) 56 data bytes
64 bytes from 2001:db8:402:402::2: icmp_seq=1 ttl=64 time=0.162 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=2 ttl=64 time=0.076 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=3 ttl=64 time=0.059 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=4 ttl=64 time=0.059 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=5 ttl=64 time=0.085 ms

--- 2001:db8:402:402::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.059/0.088/0.162/0.038 ms
5e43a337-1bda-4551-b289-832e8cb53a94
Configuring hostA (h4)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6 -c5 -i0.2 2001:db8:421:421::2'
PING 2001:db8:421:421::2(2001:db8:421:421::2) 56 data bytes
64 bytes from 2001:db8:421:421::2: icmp_seq=1 ttl=64 time=0.127 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=2 ttl=64 time=0.053 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=3 ttl=64 time=0.050 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=4 ttl=64 time=0.050 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=5 ttl=64 time=0.056 ms

--- 2001:db8:421:421::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.050/0.067/0.127/0.029 ms
676b2557-95a3-429c-8d3f-ae0e5a691e2a
Configuring hostA (h2)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6 -c5 -i0.2 2001:db8:411:411::2'
PING 2001:db8:411:411::2(2001:db8:411:411::2) 56 data bytes
64 bytes from 2001:db8:411:411::2: icmp_seq=1 ttl=64 time=0.188 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=2 ttl=64 time=0.075 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=3 ttl=64 time=0.069 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=4 ttl=64 time=0.080 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=5 ttl=64 time=0.066 ms

--- 2001:db8:411:411::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.066/0.095/0.188/0.046 ms
6a692b3e-d8c3-4241-b39f-5e462bdd2d9b
Configuring hostA (h3)...
Configuring hostZ (h2)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:400:400::2'
PING 2001:db8:400:400::2(2001:db8:400:400::2) 56 data bytes
64 bytes from 2001:db8:400:400::2: icmp_seq=1 ttl=64 time=0.163 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=2 ttl=64 time=0.098 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=3 ttl=64 time=0.123 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=4 ttl=64 time=0.090 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=5 ttl=64 time=0.099 ms

--- 2001:db8:400:400::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 812ms
rtt min/avg/max/mdev = 0.090/0.114/0.163/0.026 ms
74ec52af-8d07-4c93-a92b-897a6e79db6c
Configuring hostA (h1)...
Configuring hostZ (h7)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6 -c5 -i0.2 2001:db8:415:415::2'
PING 2001:db8:415:415::2(2001:db8:415:415::2) 56 data bytes
64 bytes from 2001:db8:415:415::2: icmp_seq=1 ttl=64 time=0.105 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=2 ttl=64 time=0.086 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=3 ttl=64 time=0.064 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=4 ttl=64 time=0.061 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=5 ttl=64 time=0.084 ms

--- 2001:db8:415:415::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.061/0.080/0.105/0.016 ms
7f0ef481-8ac6-41f0-9aad-4e4c7f440e08
Configuring hostA (h2)...
Configuring hostZ (h4)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6 -c5 -i0.2 2001:db8:408:408::2'
PING 2001:db8:408:408::2(2001:db8:408:408::2) 56 data bytes
64 bytes from 2001:db8:408:408::2: icmp_seq=1 ttl=64 time=0.094 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=2 ttl=64 time=0.067 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=3 ttl=64 time=0.062 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=4 ttl=64 time=0.064 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=5 ttl=64 time=0.062 ms

--- 2001:db8:408:408::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.062/0.069/0.094/0.012 ms
b0422904-3c96-4aee-b623-90ff6d476fe5
Configuring hostA (h5)...
Configuring hostZ (h7)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6 -c5 -i0.2 2001:db8:422:422::2'
PING 2001:db8:422:422::2(2001:db8:422:422::2) 56 data bytes
64 bytes from 2001:db8:422:422::2: icmp_seq=1 ttl=64 time=0.089 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=2 ttl=64 time=0.057 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=3 ttl=64 time=0.056 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=4 ttl=64 time=0.107 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=5 ttl=64 time=0.059 ms

--- 2001:db8:422:422::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.056/0.073/0.107/0.020 ms
b9e69344-aa7b-4b69-bfe8-182914ef8549
Configuring hostA (h1)...
Configuring hostZ (h4)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6 -c5 -i0.2 2001:db8:413:413::2'
PING 2001:db8:413:413::2(2001:db8:413:413::2) 56 data bytes
64 bytes from 2001:db8:413:413::2: icmp_seq=1 ttl=64 time=0.137 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=2 ttl=64 time=0.032 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=3 ttl=64 time=0.110 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=4 ttl=64 time=0.058 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=5 ttl=64 time=0.061 ms

--- 2001:db8:413:413::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.032/0.079/0.137/0.038 ms
c9206388-877d-4b34-8c6a-f8f91df71705
Configuring hostA (h4)...
Configuring hostZ (h5)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6 -c5 -i0.2 2001:db8:418:418::2'
PING 2001:db8:418:418::2(2001:db8:418:418::2) 56 data bytes
64 bytes from 2001:db8:418:418::2: icmp_seq=1 ttl=64 time=0.138 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=2 ttl=64 time=0.066 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=3 ttl=64 time=0.085 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=4 ttl=64 time=0.061 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=5 ttl=64 time=0.063 ms

--- 2001:db8:418:418::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.061/0.082/0.138/0.029 ms
cf9ef53a-b6c8-42f4-a61d-87dfc3c8371b
Configuring hostA (h1)...
Configuring hostZ (h5)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6 -c5 -i0.2 2001:db8:414:414::2'
PING 2001:db8:414:414::2(2001:db8:414:414::2) 56 data bytes
64 bytes from 2001:db8:414:414::2: icmp_seq=1 ttl=64 time=0.143 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=2 ttl=64 time=0.073 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=3 ttl=64 time=0.088 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=4 ttl=64 time=0.066 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=5 ttl=64 time=0.062 ms

--- 2001:db8:414:414::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.062/0.086/0.143/0.029 ms
d8c4e636-7273-4c42-b9c3-518fe6015b5b
Configuring hostA (h7)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 109 ping6 -c5 -i0.2 2001:db8:426:426::2'
PING 2001:db8:426:426::2(2001:db8:426:426::2) 56 data bytes
64 bytes from 2001:db8:426:426::2: icmp_seq=1 ttl=64 time=0.149 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=2 ttl=64 time=0.061 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=3 ttl=64 time=0.058 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=4 ttl=64 time=0.082 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=5 ttl=64 time=0.124 ms

--- 2001:db8:426:426::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 822ms
rtt min/avg/max/mdev = 0.058/0.094/0.149/0.035 ms
da6f70a6-fc11-497b-9ff1-a234805be1e7
Configuring hostA (h2)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6 -c5 -i0.2 2001:db8:412:412::2'
PING 2001:db8:412:412::2(2001:db8:412:412::2) 56 data bytes
64 bytes from 2001:db8:412:412::2: icmp_seq=1 ttl=64 time=0.104 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=2 ttl=64 time=0.067 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=3 ttl=64 time=0.064 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=4 ttl=64 time=0.063 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=5 ttl=64 time=0.058 ms

--- 2001:db8:412:412::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 818ms
rtt min/avg/max/mdev = 0.058/0.071/0.104/0.016 ms
ddc37709-9a91-4c20-9f88-963b0967f47e
Configuring hostA (h2)...
Configuring hostZ (h1)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6 -c5 -i0.2 2001:db8:407:407::2'
PING 2001:db8:407:407::2(2001:db8:407:407::2) 56 data bytes
64 bytes from 2001:db8:407:407::2: icmp_seq=1 ttl=64 time=0.161 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=2 ttl=64 time=0.068 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=3 ttl=64 time=0.059 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=4 ttl=64 time=0.055 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=5 ttl=64 time=0.058 ms

--- 2001:db8:407:407::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.055/0.080/0.161/0.040 ms
f1fdc383-0852-4302-a4f4-0e07fbf980f1
Configuring hostA (h1)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6 -c5 -i0.2 2001:db8:417:417::2'
PING 2001:db8:417:417::2(2001:db8:417:417::2) 56 data bytes
64 bytes from 2001:db8:417:417::2: icmp_seq=1 ttl=64 time=0.162 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=2 ttl=64 time=0.105 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=3 ttl=64 time=0.067 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=4 ttl=64 time=0.082 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=5 ttl=64 time=0.063 ms

--- 2001:db8:417:417::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.063/0.095/0.162/0.036 ms
f680a85a-0e26-4225-95d9-ccbeebf293de
Configuring hostA (h5)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6 -c5 -i0.2 2001:db8:424:424::2'
PING 2001:db8:424:424::2(2001:db8:424:424::2) 56 data bytes
64 bytes from 2001:db8:424:424::2: icmp_seq=1 ttl=64 time=0.103 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=2 ttl=64 time=0.121 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=3 ttl=64 time=0.104 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=4 ttl=64 time=0.112 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=5 ttl=64 time=0.094 ms

--- 2001:db8:424:424::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.094/0.106/0.121/0.009 ms
febc8a1b-0376-4f5f-a034-e9addf1a55ca
Configuring hostA (h3)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:406:406::2'
PING 2001:db8:406:406::2(2001:db8:406:406::2) 56 data bytes
64 bytes from 2001:db8:406:406::2: icmp_seq=1 ttl=64 time=0.166 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=2 ttl=64 time=0.068 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=3 ttl=64 time=0.092 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=4 ttl=64 time=0.065 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=5 ttl=64 time=0.061 ms

--- 2001:db8:406:406::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.061/0.090/0.166/0.039 ms
ff5c0bda-7b9d-47a3-8486-ed67cf6b4eba
Configuring hostA (h4)...
Configuring hostZ (h7)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6 -c5 -i0.2 2001:db8:419:419::2'
PING 2001:db8:419:419::2(2001:db8:419:419::2) 56 data bytes
64 bytes from 2001:db8:419:419::2: icmp_seq=1 ttl=64 time=0.137 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=2 ttl=64 time=0.075 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=3 ttl=64 time=0.065 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=4 ttl=64 time=0.067 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=5 ttl=64 time=0.066 ms

--- 2001:db8:419:419::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.065/0.082/0.137/0.027 ms
```

4. Simulating two link failures:
```
$ docker compose exec -it mininet ip link set down Ampath2-eth40

# wait a few seconds
# run Connectivity tests:

$ curl -s http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0  | jq -r '.[]|.service_id' | while read ID; do echo $ID; ./test-l2vpn-v2.sh $ID ping-only -c5; done
030c5a16-f68f-4c38-b61d-28a324bc9e31
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 111 ping6  -i0.2 2001:db8:427:427::2 -c5'
PING 2001:db8:427:427::2(2001:db8:427:427::2) 56 data bytes
64 bytes from 2001:db8:427:427::2: icmp_seq=1 ttl=64 time=0.747 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=2 ttl=64 time=0.063 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=3 ttl=64 time=0.058 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=4 ttl=64 time=0.057 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=5 ttl=64 time=0.060 ms

--- 2001:db8:427:427::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.057/0.197/0.747/0.275 ms
05e5eb19-fce2-4b20-b418-5fc8feb79de5
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:403:403::2 -c5'
PING 2001:db8:403:403::2(2001:db8:403:403::2) 56 data bytes
64 bytes from 2001:db8:403:403::2: icmp_seq=1 ttl=64 time=1.21 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=2 ttl=64 time=0.074 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=3 ttl=64 time=0.083 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=4 ttl=64 time=0.069 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=5 ttl=64 time=0.092 ms

--- 2001:db8:403:403::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 810ms
rtt min/avg/max/mdev = 0.069/0.305/1.208/0.451 ms
0e0b376e-a7cb-44be-8ef3-ef779a516fd9
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:410:410::2 -c5'
PING 2001:db8:410:410::2(2001:db8:410:410::2) 56 data bytes
64 bytes from 2001:db8:410:410::2: icmp_seq=1 ttl=64 time=1.13 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=2 ttl=64 time=0.078 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=3 ttl=64 time=0.085 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=4 ttl=64 time=0.085 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=5 ttl=64 time=0.069 ms

--- 2001:db8:410:410::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 809ms
rtt min/avg/max/mdev = 0.069/0.289/1.132/0.421 ms
162f2616-6cb6-48fa-a7e1-0e2b79e91ac1
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 109 ping6  -i0.2 2001:db8:425:425::2 -c5'
PING 2001:db8:425:425::2(2001:db8:425:425::2) 56 data bytes
64 bytes from 2001:db8:425:425::2: icmp_seq=1 ttl=64 time=1.05 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=2 ttl=64 time=0.068 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=3 ttl=64 time=0.115 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=4 ttl=64 time=0.104 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=5 ttl=64 time=0.072 ms

--- 2001:db8:425:425::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.068/0.281/1.050/0.384 ms
25a3ceef-ec01-46c3-a2c8-cc03ad42966e
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:401:401::2 -c5'
PING 2001:db8:401:401::2(2001:db8:401:401::2) 56 data bytes
64 bytes from 2001:db8:401:401::2: icmp_seq=1 ttl=64 time=0.770 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=2 ttl=64 time=0.063 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=3 ttl=64 time=0.073 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=4 ttl=64 time=0.057 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=5 ttl=64 time=0.073 ms

--- 2001:db8:401:401::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.057/0.207/0.770/0.281 ms
26e1a894-f3c7-4d1c-859c-54d34b6d9e44
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:404:404::2 -c5'
PING 2001:db8:404:404::2(2001:db8:404:404::2) 56 data bytes
64 bytes from 2001:db8:404:404::2: icmp_seq=1 ttl=64 time=1.20 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=2 ttl=64 time=0.084 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=3 ttl=64 time=0.080 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=4 ttl=64 time=0.039 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=5 ttl=64 time=0.071 ms

--- 2001:db8:404:404::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.039/0.295/1.204/0.454 ms
2d6348ca-1a0b-4d85-9c72-7caaa4bc01bb
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6  -i0.2 2001:db8:423:423::2 -c5'
PING 2001:db8:423:423::2(2001:db8:423:423::2) 56 data bytes
64 bytes from 2001:db8:423:423::2: icmp_seq=1 ttl=64 time=0.723 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=2 ttl=64 time=0.098 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=3 ttl=64 time=0.070 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=4 ttl=64 time=0.065 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=5 ttl=64 time=0.097 ms

--- 2001:db8:423:423::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 828ms
rtt min/avg/max/mdev = 0.065/0.210/0.723/0.256 ms
2e2060a1-6d8c-44b2-9dc9-c7762d0c052b
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:405:405::2 -c5'
PING 2001:db8:405:405::2(2001:db8:405:405::2) 56 data bytes
64 bytes from 2001:db8:405:405::2: icmp_seq=1 ttl=64 time=1.42 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=2 ttl=64 time=0.104 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=3 ttl=64 time=0.071 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=4 ttl=64 time=0.089 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=5 ttl=64 time=0.049 ms

--- 2001:db8:405:405::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.049/0.347/1.424/0.538 ms
4a050ea8-5745-461e-a929-7137c4aaff40
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:409:409::2 -c5'
PING 2001:db8:409:409::2(2001:db8:409:409::2) 56 data bytes
64 bytes from 2001:db8:409:409::2: icmp_seq=1 ttl=64 time=0.864 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=2 ttl=64 time=0.090 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=3 ttl=64 time=0.067 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=4 ttl=64 time=0.063 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=5 ttl=64 time=0.060 ms

--- 2001:db8:409:409::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.060/0.228/0.864/0.317 ms
53b6263c-0bfb-414d-8a93-9423c36f201d
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:416:416::2 -c5'
PING 2001:db8:416:416::2(2001:db8:416:416::2) 56 data bytes
64 bytes from 2001:db8:416:416::2: icmp_seq=1 ttl=64 time=0.982 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=2 ttl=64 time=0.075 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=3 ttl=64 time=0.061 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=4 ttl=64 time=0.065 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=5 ttl=64 time=0.066 ms

--- 2001:db8:416:416::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 810ms
rtt min/avg/max/mdev = 0.061/0.249/0.982/0.366 ms
5c614b85-e4d9-43fa-913d-03d2f586bd77
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6  -i0.2 2001:db8:420:420::2 -c5'
PING 2001:db8:420:420::2(2001:db8:420:420::2) 56 data bytes
64 bytes from 2001:db8:420:420::2: icmp_seq=1 ttl=64 time=0.928 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=2 ttl=64 time=0.072 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=3 ttl=64 time=0.081 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=4 ttl=64 time=0.055 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=5 ttl=64 time=0.056 ms

--- 2001:db8:420:420::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.055/0.238/0.928/0.344 ms
5d8289dd-aecf-4d78-bfa3-5d26f332cd28
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:402:402::2 -c5'
PING 2001:db8:402:402::2(2001:db8:402:402::2) 56 data bytes
64 bytes from 2001:db8:402:402::2: icmp_seq=1 ttl=64 time=1.10 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=2 ttl=64 time=0.094 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=3 ttl=64 time=0.065 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=4 ttl=64 time=0.111 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=5 ttl=64 time=0.087 ms

--- 2001:db8:402:402::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.065/0.291/1.098/0.403 ms
5e43a337-1bda-4551-b289-832e8cb53a94
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6  -i0.2 2001:db8:421:421::2 -c5'
PING 2001:db8:421:421::2(2001:db8:421:421::2) 56 data bytes
64 bytes from 2001:db8:421:421::2: icmp_seq=1 ttl=64 time=0.813 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=2 ttl=64 time=0.066 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=3 ttl=64 time=0.058 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=4 ttl=64 time=0.058 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=5 ttl=64 time=0.048 ms

--- 2001:db8:421:421::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.048/0.208/0.813/0.302 ms
676b2557-95a3-429c-8d3f-ae0e5a691e2a
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:411:411::2 -c5'
PING 2001:db8:411:411::2(2001:db8:411:411::2) 56 data bytes
64 bytes from 2001:db8:411:411::2: icmp_seq=1 ttl=64 time=1.29 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=2 ttl=64 time=0.078 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=3 ttl=64 time=0.070 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=4 ttl=64 time=0.071 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=5 ttl=64 time=0.069 ms

--- 2001:db8:411:411::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 809ms
rtt min/avg/max/mdev = 0.069/0.315/1.288/0.486 ms
6a692b3e-d8c3-4241-b39f-5e462bdd2d9b
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:400:400::2 -c5'
PING 2001:db8:400:400::2(2001:db8:400:400::2) 56 data bytes
64 bytes from 2001:db8:400:400::2: icmp_seq=1 ttl=64 time=0.724 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=2 ttl=64 time=0.087 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=3 ttl=64 time=0.106 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=4 ttl=64 time=0.089 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=5 ttl=64 time=0.072 ms

--- 2001:db8:400:400::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 816ms
rtt min/avg/max/mdev = 0.072/0.215/0.724/0.254 ms
74ec52af-8d07-4c93-a92b-897a6e79db6c
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:415:415::2 -c5'
PING 2001:db8:415:415::2(2001:db8:415:415::2) 56 data bytes
64 bytes from 2001:db8:415:415::2: icmp_seq=1 ttl=64 time=0.967 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=2 ttl=64 time=0.114 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=3 ttl=64 time=0.071 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=4 ttl=64 time=0.114 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=5 ttl=64 time=0.069 ms

--- 2001:db8:415:415::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 810ms
rtt min/avg/max/mdev = 0.069/0.267/0.967/0.350 ms
7f0ef481-8ac6-41f0-9aad-4e4c7f440e08
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:408:408::2 -c5'
PING 2001:db8:408:408::2(2001:db8:408:408::2) 56 data bytes
64 bytes from 2001:db8:408:408::2: icmp_seq=1 ttl=64 time=0.796 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=2 ttl=64 time=0.078 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=3 ttl=64 time=0.066 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=4 ttl=64 time=0.063 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=5 ttl=64 time=0.066 ms

--- 2001:db8:408:408::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.063/0.213/0.796/0.291 ms
b0422904-3c96-4aee-b623-90ff6d476fe5
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6  -i0.2 2001:db8:422:422::2 -c5'
PING 2001:db8:422:422::2(2001:db8:422:422::2) 56 data bytes
64 bytes from 2001:db8:422:422::2: icmp_seq=1 ttl=64 time=0.674 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=2 ttl=64 time=0.078 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=3 ttl=64 time=0.055 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=4 ttl=64 time=0.057 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=5 ttl=64 time=0.059 ms

--- 2001:db8:422:422::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.055/0.184/0.674/0.244 ms
b9e69344-aa7b-4b69-bfe8-182914ef8549
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:413:413::2 -c5'
PING 2001:db8:413:413::2(2001:db8:413:413::2) 56 data bytes
64 bytes from 2001:db8:413:413::2: icmp_seq=1 ttl=64 time=0.689 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=2 ttl=64 time=0.064 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=3 ttl=64 time=0.056 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=4 ttl=64 time=0.058 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=5 ttl=64 time=0.056 ms

--- 2001:db8:413:413::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.056/0.184/0.689/0.252 ms
c9206388-877d-4b34-8c6a-f8f91df71705
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6  -i0.2 2001:db8:418:418::2 -c5'
PING 2001:db8:418:418::2(2001:db8:418:418::2) 56 data bytes
64 bytes from 2001:db8:418:418::2: icmp_seq=1 ttl=64 time=0.660 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=2 ttl=64 time=0.072 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=3 ttl=64 time=0.124 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=4 ttl=64 time=0.086 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=5 ttl=64 time=0.096 ms

--- 2001:db8:418:418::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.072/0.207/0.660/0.226 ms
cf9ef53a-b6c8-42f4-a61d-87dfc3c8371b
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:414:414::2 -c5'
PING 2001:db8:414:414::2(2001:db8:414:414::2) 56 data bytes
64 bytes from 2001:db8:414:414::2: icmp_seq=1 ttl=64 time=0.895 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=2 ttl=64 time=0.075 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=3 ttl=64 time=0.055 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=4 ttl=64 time=0.080 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=5 ttl=64 time=0.064 ms

--- 2001:db8:414:414::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.055/0.233/0.895/0.330 ms
d8c4e636-7273-4c42-b9c3-518fe6015b5b
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 109 ping6  -i0.2 2001:db8:426:426::2 -c5'
PING 2001:db8:426:426::2(2001:db8:426:426::2) 56 data bytes
64 bytes from 2001:db8:426:426::2: icmp_seq=1 ttl=64 time=0.693 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=2 ttl=64 time=0.067 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=3 ttl=64 time=0.059 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=4 ttl=64 time=0.060 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=5 ttl=64 time=0.064 ms

--- 2001:db8:426:426::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.059/0.188/0.693/0.252 ms
da6f70a6-fc11-497b-9ff1-a234805be1e7
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:412:412::2 -c5'
PING 2001:db8:412:412::2(2001:db8:412:412::2) 56 data bytes
64 bytes from 2001:db8:412:412::2: icmp_seq=1 ttl=64 time=0.857 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=2 ttl=64 time=0.116 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=3 ttl=64 time=0.128 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=4 ttl=64 time=0.068 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=5 ttl=64 time=0.065 ms

--- 2001:db8:412:412::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.065/0.246/0.857/0.306 ms
ddc37709-9a91-4c20-9f88-963b0967f47e
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:407:407::2 -c5'
PING 2001:db8:407:407::2(2001:db8:407:407::2) 56 data bytes
64 bytes from 2001:db8:407:407::2: icmp_seq=1 ttl=64 time=0.769 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=2 ttl=64 time=0.073 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=3 ttl=64 time=0.087 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=4 ttl=64 time=0.067 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=5 ttl=64 time=0.062 ms

--- 2001:db8:407:407::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.062/0.211/0.769/0.278 ms
f1fdc383-0852-4302-a4f4-0e07fbf980f1
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:417:417::2 -c5'
PING 2001:db8:417:417::2(2001:db8:417:417::2) 56 data bytes
64 bytes from 2001:db8:417:417::2: icmp_seq=1 ttl=64 time=0.669 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=2 ttl=64 time=0.072 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=3 ttl=64 time=0.060 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=4 ttl=64 time=0.060 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=5 ttl=64 time=0.065 ms

--- 2001:db8:417:417::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.060/0.185/0.669/0.241 ms
f680a85a-0e26-4225-95d9-ccbeebf293de
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6  -i0.2 2001:db8:424:424::2 -c5'
PING 2001:db8:424:424::2(2001:db8:424:424::2) 56 data bytes
64 bytes from 2001:db8:424:424::2: icmp_seq=1 ttl=64 time=0.780 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=2 ttl=64 time=0.088 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=3 ttl=64 time=0.063 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=4 ttl=64 time=0.068 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=5 ttl=64 time=0.053 ms

--- 2001:db8:424:424::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.053/0.210/0.780/0.285 ms
febc8a1b-0376-4f5f-a034-e9addf1a55ca
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:406:406::2 -c5'
PING 2001:db8:406:406::2(2001:db8:406:406::2) 56 data bytes
64 bytes from 2001:db8:406:406::2: icmp_seq=1 ttl=64 time=1.18 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=2 ttl=64 time=0.077 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=3 ttl=64 time=0.063 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=4 ttl=64 time=0.066 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=5 ttl=64 time=0.063 ms

--- 2001:db8:406:406::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 810ms
rtt min/avg/max/mdev = 0.063/0.290/1.182/0.445 ms
ff5c0bda-7b9d-47a3-8486-ed67cf6b4eba
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6  -i0.2 2001:db8:419:419::2 -c5'
PING 2001:db8:419:419::2(2001:db8:419:419::2) 56 data bytes
64 bytes from 2001:db8:419:419::2: icmp_seq=1 ttl=64 time=0.737 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=2 ttl=64 time=0.075 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=3 ttl=64 time=0.068 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=4 ttl=64 time=0.131 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=5 ttl=64 time=0.112 ms

--- 2001:db8:419:419::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.068/0.224/0.737/0.257 ms
```

5. SImulate another link failure:
```
$ docker compose exec -it mininet ip link set down Tenet01-eth41

# wait a few seconds

# run connectivity tests again:

$ curl -s http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0  | jq -r '.[]|.service_id' | while read ID; do echo $ID; ./test-l2vpn-v2.sh $ID ping-only -c5; done
030c5a16-f68f-4c38-b61d-28a324bc9e31
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 111 ping6  -i0.2 2001:db8:427:427::2 -c5'
PING 2001:db8:427:427::2(2001:db8:427:427::2) 56 data bytes
64 bytes from 2001:db8:427:427::2: icmp_seq=1 ttl=64 time=0.699 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=2 ttl=64 time=0.075 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=3 ttl=64 time=0.056 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=4 ttl=64 time=0.060 ms
64 bytes from 2001:db8:427:427::2: icmp_seq=5 ttl=64 time=0.075 ms

--- 2001:db8:427:427::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.056/0.193/0.699/0.253 ms
05e5eb19-fce2-4b20-b418-5fc8feb79de5
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:403:403::2 -c5'
PING 2001:db8:403:403::2(2001:db8:403:403::2) 56 data bytes
64 bytes from 2001:db8:403:403::2: icmp_seq=1 ttl=64 time=0.793 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=2 ttl=64 time=0.092 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=3 ttl=64 time=0.067 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=4 ttl=64 time=0.077 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=5 ttl=64 time=0.063 ms

--- 2001:db8:403:403::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.063/0.218/0.793/0.287 ms
0e0b376e-a7cb-44be-8ef3-ef779a516fd9
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:410:410::2 -c5'
PING 2001:db8:410:410::2(2001:db8:410:410::2) 56 data bytes
64 bytes from 2001:db8:410:410::2: icmp_seq=1 ttl=64 time=0.964 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=2 ttl=64 time=0.091 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=3 ttl=64 time=0.072 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=4 ttl=64 time=0.071 ms
64 bytes from 2001:db8:410:410::2: icmp_seq=5 ttl=64 time=0.067 ms

--- 2001:db8:410:410::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.067/0.253/0.964/0.355 ms
162f2616-6cb6-48fa-a7e1-0e2b79e91ac1
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 109 ping6  -i0.2 2001:db8:425:425::2 -c5'
PING 2001:db8:425:425::2(2001:db8:425:425::2) 56 data bytes
64 bytes from 2001:db8:425:425::2: icmp_seq=1 ttl=64 time=1.05 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=2 ttl=64 time=0.061 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=3 ttl=64 time=0.081 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=4 ttl=64 time=0.131 ms
64 bytes from 2001:db8:425:425::2: icmp_seq=5 ttl=64 time=0.096 ms

--- 2001:db8:425:425::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.061/0.284/1.053/0.384 ms
25a3ceef-ec01-46c3-a2c8-cc03ad42966e
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:401:401::2 -c5'
PING 2001:db8:401:401::2(2001:db8:401:401::2) 56 data bytes
64 bytes from 2001:db8:401:401::2: icmp_seq=1 ttl=64 time=0.740 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=2 ttl=64 time=0.038 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=3 ttl=64 time=0.060 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=4 ttl=64 time=0.055 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=5 ttl=64 time=0.056 ms

--- 2001:db8:401:401::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.038/0.189/0.740/0.275 ms
26e1a894-f3c7-4d1c-859c-54d34b6d9e44
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:404:404::2 -c5'
PING 2001:db8:404:404::2(2001:db8:404:404::2) 56 data bytes
64 bytes from 2001:db8:404:404::2: icmp_seq=1 ttl=64 time=0.878 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=2 ttl=64 time=0.093 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=3 ttl=64 time=0.071 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=4 ttl=64 time=0.067 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=5 ttl=64 time=0.067 ms

--- 2001:db8:404:404::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 818ms
rtt min/avg/max/mdev = 0.067/0.235/0.878/0.321 ms
2d6348ca-1a0b-4d85-9c72-7caaa4bc01bb
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6  -i0.2 2001:db8:423:423::2 -c5'
PING 2001:db8:423:423::2(2001:db8:423:423::2) 56 data bytes
64 bytes from 2001:db8:423:423::2: icmp_seq=1 ttl=64 time=0.618 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=2 ttl=64 time=0.085 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=3 ttl=64 time=0.100 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=4 ttl=64 time=0.090 ms
64 bytes from 2001:db8:423:423::2: icmp_seq=5 ttl=64 time=0.065 ms

--- 2001:db8:423:423::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.065/0.191/0.618/0.213 ms
2e2060a1-6d8c-44b2-9dc9-c7762d0c052b
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:405:405::2 -c5'
PING 2001:db8:405:405::2(2001:db8:405:405::2) 56 data bytes
64 bytes from 2001:db8:405:405::2: icmp_seq=1 ttl=64 time=1.69 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=2 ttl=64 time=0.093 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=3 ttl=64 time=0.080 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=4 ttl=64 time=0.079 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=5 ttl=64 time=0.078 ms

--- 2001:db8:405:405::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.078/0.404/1.691/0.643 ms
4a050ea8-5745-461e-a929-7137c4aaff40
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:409:409::2 -c5'
PING 2001:db8:409:409::2(2001:db8:409:409::2) 56 data bytes
64 bytes from 2001:db8:409:409::2: icmp_seq=1 ttl=64 time=1.05 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=2 ttl=64 time=0.073 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=3 ttl=64 time=0.068 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=4 ttl=64 time=0.065 ms
64 bytes from 2001:db8:409:409::2: icmp_seq=5 ttl=64 time=0.064 ms

--- 2001:db8:409:409::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 811ms
rtt min/avg/max/mdev = 0.064/0.263/1.048/0.392 ms
53b6263c-0bfb-414d-8a93-9423c36f201d
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:416:416::2 -c5'
PING 2001:db8:416:416::2(2001:db8:416:416::2) 56 data bytes
64 bytes from 2001:db8:416:416::2: icmp_seq=1 ttl=64 time=1.24 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=2 ttl=64 time=0.084 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=3 ttl=64 time=0.095 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=4 ttl=64 time=0.071 ms
64 bytes from 2001:db8:416:416::2: icmp_seq=5 ttl=64 time=0.066 ms

--- 2001:db8:416:416::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 809ms
rtt min/avg/max/mdev = 0.066/0.311/1.240/0.464 ms
5c614b85-e4d9-43fa-913d-03d2f586bd77
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6  -i0.2 2001:db8:420:420::2 -c5'
PING 2001:db8:420:420::2(2001:db8:420:420::2) 56 data bytes
64 bytes from 2001:db8:420:420::2: icmp_seq=1 ttl=64 time=1.42 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=2 ttl=64 time=0.078 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=3 ttl=64 time=0.082 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=4 ttl=64 time=0.078 ms
64 bytes from 2001:db8:420:420::2: icmp_seq=5 ttl=64 time=0.064 ms

--- 2001:db8:420:420::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 812ms
rtt min/avg/max/mdev = 0.064/0.343/1.415/0.535 ms
5d8289dd-aecf-4d78-bfa3-5d26f332cd28
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:402:402::2 -c5'
PING 2001:db8:402:402::2(2001:db8:402:402::2) 56 data bytes
64 bytes from 2001:db8:402:402::2: icmp_seq=1 ttl=64 time=0.815 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=2 ttl=64 time=0.074 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=3 ttl=64 time=0.060 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=4 ttl=64 time=0.065 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=5 ttl=64 time=0.089 ms

--- 2001:db8:402:402::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 818ms
rtt min/avg/max/mdev = 0.060/0.220/0.815/0.297 ms
5e43a337-1bda-4551-b289-832e8cb53a94
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6  -i0.2 2001:db8:421:421::2 -c5'
PING 2001:db8:421:421::2(2001:db8:421:421::2) 56 data bytes
64 bytes from 2001:db8:421:421::2: icmp_seq=1 ttl=64 time=1.20 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=2 ttl=64 time=0.094 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=3 ttl=64 time=0.068 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=4 ttl=64 time=0.064 ms
64 bytes from 2001:db8:421:421::2: icmp_seq=5 ttl=64 time=0.074 ms

--- 2001:db8:421:421::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.064/0.299/1.197/0.448 ms
676b2557-95a3-429c-8d3f-ae0e5a691e2a
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:411:411::2 -c5'
PING 2001:db8:411:411::2(2001:db8:411:411::2) 56 data bytes
64 bytes from 2001:db8:411:411::2: icmp_seq=1 ttl=64 time=1.64 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=2 ttl=64 time=0.085 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=3 ttl=64 time=0.080 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=4 ttl=64 time=0.085 ms
64 bytes from 2001:db8:411:411::2: icmp_seq=5 ttl=64 time=0.077 ms

--- 2001:db8:411:411::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.077/0.393/1.638/0.622 ms
6a692b3e-d8c3-4241-b39f-5e462bdd2d9b
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:400:400::2 -c5'
PING 2001:db8:400:400::2(2001:db8:400:400::2) 56 data bytes
64 bytes from 2001:db8:400:400::2: icmp_seq=1 ttl=64 time=0.381 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=2 ttl=64 time=0.063 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=3 ttl=64 time=0.107 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=4 ttl=64 time=0.056 ms
64 bytes from 2001:db8:400:400::2: icmp_seq=5 ttl=64 time=0.055 ms

--- 2001:db8:400:400::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.055/0.132/0.381/0.125 ms
74ec52af-8d07-4c93-a92b-897a6e79db6c
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:415:415::2 -c5'
PING 2001:db8:415:415::2(2001:db8:415:415::2) 56 data bytes
64 bytes from 2001:db8:415:415::2: icmp_seq=1 ttl=64 time=1.02 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=2 ttl=64 time=0.075 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=3 ttl=64 time=0.066 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=4 ttl=64 time=0.065 ms
64 bytes from 2001:db8:415:415::2: icmp_seq=5 ttl=64 time=0.065 ms

--- 2001:db8:415:415::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 810ms
rtt min/avg/max/mdev = 0.065/0.258/1.020/0.380 ms
7f0ef481-8ac6-41f0-9aad-4e4c7f440e08
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:408:408::2 -c5'
PING 2001:db8:408:408::2(2001:db8:408:408::2) 56 data bytes
64 bytes from 2001:db8:408:408::2: icmp_seq=1 ttl=64 time=0.991 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=2 ttl=64 time=0.073 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=3 ttl=64 time=0.081 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=4 ttl=64 time=0.068 ms
64 bytes from 2001:db8:408:408::2: icmp_seq=5 ttl=64 time=0.101 ms

--- 2001:db8:408:408::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 811ms
rtt min/avg/max/mdev = 0.068/0.262/0.991/0.364 ms
b0422904-3c96-4aee-b623-90ff6d476fe5
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6  -i0.2 2001:db8:422:422::2 -c5'
PING 2001:db8:422:422::2(2001:db8:422:422::2) 56 data bytes
64 bytes from 2001:db8:422:422::2: icmp_seq=1 ttl=64 time=0.647 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=2 ttl=64 time=0.070 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=3 ttl=64 time=0.052 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=4 ttl=64 time=0.055 ms
64 bytes from 2001:db8:422:422::2: icmp_seq=5 ttl=64 time=0.054 ms

--- 2001:db8:422:422::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.052/0.175/0.647/0.235 ms
b9e69344-aa7b-4b69-bfe8-182914ef8549
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:413:413::2 -c5'
PING 2001:db8:413:413::2(2001:db8:413:413::2) 56 data bytes
64 bytes from 2001:db8:413:413::2: icmp_seq=1 ttl=64 time=0.485 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=2 ttl=64 time=0.078 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=3 ttl=64 time=0.069 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=4 ttl=64 time=0.064 ms
64 bytes from 2001:db8:413:413::2: icmp_seq=5 ttl=64 time=0.058 ms

--- 2001:db8:413:413::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.058/0.150/0.485/0.167 ms
c9206388-877d-4b34-8c6a-f8f91df71705
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6  -i0.2 2001:db8:418:418::2 -c5'
PING 2001:db8:418:418::2(2001:db8:418:418::2) 56 data bytes
64 bytes from 2001:db8:418:418::2: icmp_seq=1 ttl=64 time=0.493 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=2 ttl=64 time=0.072 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=3 ttl=64 time=0.074 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=4 ttl=64 time=0.078 ms
64 bytes from 2001:db8:418:418::2: icmp_seq=5 ttl=64 time=0.059 ms

--- 2001:db8:418:418::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.059/0.155/0.493/0.169 ms
cf9ef53a-b6c8-42f4-a61d-87dfc3c8371b
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:414:414::2 -c5'
PING 2001:db8:414:414::2(2001:db8:414:414::2) 56 data bytes
64 bytes from 2001:db8:414:414::2: icmp_seq=1 ttl=64 time=0.870 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=2 ttl=64 time=0.084 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=3 ttl=64 time=0.067 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=4 ttl=64 time=0.061 ms
64 bytes from 2001:db8:414:414::2: icmp_seq=5 ttl=64 time=0.057 ms

--- 2001:db8:414:414::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.057/0.227/0.870/0.321 ms
d8c4e636-7273-4c42-b9c3-518fe6015b5b
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 109 ping6  -i0.2 2001:db8:426:426::2 -c5'
PING 2001:db8:426:426::2(2001:db8:426:426::2) 56 data bytes
64 bytes from 2001:db8:426:426::2: icmp_seq=1 ttl=64 time=0.571 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=2 ttl=64 time=0.067 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=3 ttl=64 time=0.059 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=4 ttl=64 time=0.055 ms
64 bytes from 2001:db8:426:426::2: icmp_seq=5 ttl=64 time=0.060 ms

--- 2001:db8:426:426::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.055/0.162/0.571/0.204 ms
da6f70a6-fc11-497b-9ff1-a234805be1e7
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:412:412::2 -c5'
PING 2001:db8:412:412::2(2001:db8:412:412::2) 56 data bytes
64 bytes from 2001:db8:412:412::2: icmp_seq=1 ttl=64 time=1.50 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=2 ttl=64 time=0.139 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=3 ttl=64 time=0.094 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=4 ttl=64 time=0.129 ms
64 bytes from 2001:db8:412:412::2: icmp_seq=5 ttl=64 time=0.073 ms

--- 2001:db8:412:412::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 810ms
rtt min/avg/max/mdev = 0.073/0.387/1.504/0.558 ms
ddc37709-9a91-4c20-9f88-963b0967f47e
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 169 ping6  -i0.2 2001:db8:407:407::2 -c5'
PING 2001:db8:407:407::2(2001:db8:407:407::2) 56 data bytes
64 bytes from 2001:db8:407:407::2: icmp_seq=1 ttl=64 time=0.768 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=2 ttl=64 time=0.092 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=3 ttl=64 time=0.056 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=4 ttl=64 time=0.073 ms
64 bytes from 2001:db8:407:407::2: icmp_seq=5 ttl=64 time=0.057 ms

--- 2001:db8:407:407::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.056/0.209/0.768/0.279 ms
f1fdc383-0852-4302-a4f4-0e07fbf980f1
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 167 ping6  -i0.2 2001:db8:417:417::2 -c5'
PING 2001:db8:417:417::2(2001:db8:417:417::2) 56 data bytes
64 bytes from 2001:db8:417:417::2: icmp_seq=1 ttl=64 time=0.936 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=2 ttl=64 time=0.112 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=3 ttl=64 time=0.093 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=4 ttl=64 time=0.087 ms
64 bytes from 2001:db8:417:417::2: icmp_seq=5 ttl=64 time=0.069 ms

--- 2001:db8:417:417::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.069/0.259/0.936/0.338 ms
f680a85a-0e26-4225-95d9-ccbeebf293de
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 137 ping6  -i0.2 2001:db8:424:424::2 -c5'
PING 2001:db8:424:424::2(2001:db8:424:424::2) 56 data bytes
64 bytes from 2001:db8:424:424::2: icmp_seq=1 ttl=64 time=0.721 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=2 ttl=64 time=0.066 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=3 ttl=64 time=0.089 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=4 ttl=64 time=0.063 ms
64 bytes from 2001:db8:424:424::2: icmp_seq=5 ttl=64 time=0.063 ms

--- 2001:db8:424:424::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.063/0.200/0.721/0.260 ms
febc8a1b-0376-4f5f-a034-e9addf1a55ca
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 171 ping6  -i0.2 2001:db8:406:406::2 -c5'
PING 2001:db8:406:406::2(2001:db8:406:406::2) 56 data bytes
64 bytes from 2001:db8:406:406::2: icmp_seq=1 ttl=64 time=1.39 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=2 ttl=64 time=0.088 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=3 ttl=64 time=0.074 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=4 ttl=64 time=0.088 ms
64 bytes from 2001:db8:406:406::2: icmp_seq=5 ttl=64 time=0.112 ms

--- 2001:db8:406:406::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 809ms
rtt min/avg/max/mdev = 0.074/0.349/1.387/0.518 ms
ff5c0bda-7b9d-47a3-8486-ed67cf6b4eba
ping test HostA - HostB
+ docker exec 835f6b7efaa9b1af2fee8c188005c8f79bc1074c149c1580c229a5ba01ccee3c bash -c 'mnexec -a 135 ping6  -i0.2 2001:db8:419:419::2 -c5'
PING 2001:db8:419:419::2(2001:db8:419:419::2) 56 data bytes
64 bytes from 2001:db8:419:419::2: icmp_seq=1 ttl=64 time=0.701 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=2 ttl=64 time=0.088 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=3 ttl=64 time=0.079 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=4 ttl=64 time=0.061 ms
64 bytes from 2001:db8:419:419::2: icmp_seq=5 ttl=64 time=0.067 ms

--- 2001:db8:419:419::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 813ms
rtt min/avg/max/mdev = 0.061/0.199/0.701/0.251 ms
```

6. Finally, check the MongoDB to make sure the `status` is correct and also the `oxp_success_count`:

```
$ docker compose exec -it mongo1t mongosh "mongodb://192.168.0.6:27027/sdx_controller_db?directConnection=true&authSource=admin" --eval "config.set('displayBatchSize', 2000); db.connections.find({})"
[
  {
    _id: ObjectId('67ee91521354100e5dcc28ed'),
    '6a692b3e-d8c3-4241-b39f-5e462bdd2d9b': '{"name": "VLAN 400", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "400"}, {"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "400"}], "id": "6a692b3e-d8c3-4241-b39f-5e462bdd2d9b", "status": "UP", "oxp_success_count": 1, "oxp_response": {"ampath.net": [200, {"circuit_id": "11a2acff3ff745", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91521354100e5dcc28f3'),
    '25a3ceef-ec01-46c3-a2c8-cc03ad42966e': '{"name": "VLAN 401", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "401"}, {"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "401"}], "id": "25a3ceef-ec01-46c3-a2c8-cc03ad42966e", "status": "UP", "oxp_success_count": 1, "oxp_response": {"ampath.net": [200, {"circuit_id": "ba5e91b7d3644a", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91531354100e5dcc28f8'),
    '5d8289dd-aecf-4d78-bfa3-5d26f332cd28': '{"name": "VLAN 402", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "402"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "402"}], "id": "5d8289dd-aecf-4d78-bfa3-5d26f332cd28", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "24d57f51e6af44", "deployed": true}], "ampath.net": [200, {"circuit_id": "afe98cf6ba8d48", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91571354100e5dcc2911'),
    'ddc37709-9a91-4c20-9f88-963b0967f47e': '{"name": "VLAN 407", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "407"}, {"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "407"}], "id": "ddc37709-9a91-4c20-9f88-963b0967f47e", "status": "UP", "oxp_success_count": 1, "oxp_response": {"ampath.net": [200, {"circuit_id": "f56ce38935de46", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91581354100e5dcc2916'),
    '7f0ef481-8ac6-41f0-9aad-4e4c7f440e08': '{"name": "VLAN 408", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "408"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "408"}], "id": "7f0ef481-8ac6-41f0-9aad-4e4c7f440e08", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "b98a0d817c4d4d", "deployed": true}], "ampath.net": [200, {"circuit_id": "661ab1165d7246", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915c1354100e5dcc292f'),
    'b9e69344-aa7b-4b69-bfe8-182914ef8549': '{"name": "VLAN 413", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "413"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "413"}], "id": "b9e69344-aa7b-4b69-bfe8-182914ef8549", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "3d6a20ebc2094d", "deployed": true}], "ampath.net": [200, {"circuit_id": "33f1dd47cdc44b", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915d1354100e5dcc2934'),
    'cf9ef53a-b6c8-42f4-a61d-87dfc3c8371b': '{"name": "VLAN 414", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "414"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "414"}], "id": "cf9ef53a-b6c8-42f4-a61d-87dfc3c8371b", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "5f66e748fe4741", "deployed": true}], "ampath.net": [200, {"circuit_id": "0f3fc073f54349", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee915d1354100e5dcc2939'),
    '74ec52af-8d07-4c93-a92b-897a6e79db6c': '{"name": "VLAN 415", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "415"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "415"}], "id": "74ec52af-8d07-4c93-a92b-897a6e79db6c", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "982dedb6fc0f42", "deployed": true}], "sax.net": [200, {"circuit_id": "02cb2c1b4a864d", "deployed": true}], "ampath.net": [200, {"circuit_id": "c84436bbb41c42", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91601354100e5dcc2948'),
    'c9206388-877d-4b34-8c6a-f8f91df71705': '{"name": "VLAN 418", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "418"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "418"}], "id": "c9206388-877d-4b34-8c6a-f8f91df71705", "status": "UP", "oxp_success_count": 1, "oxp_response": {"sax.net": [200, {"circuit_id": "ee5a22af1a1f4d", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91611354100e5dcc294d'),
    'ff5c0bda-7b9d-47a3-8486-ed67cf6b4eba': '{"name": "VLAN 419", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "419"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "419"}], "id": "ff5c0bda-7b9d-47a3-8486-ed67cf6b4eba", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "27fdc8dec6b547", "deployed": true}], "sax.net": [200, {"circuit_id": "9dea6c749c664a", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91641354100e5dcc295c'),
    'b0422904-3c96-4aee-b623-90ff6d476fe5': '{"name": "VLAN 422", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "422"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "422"}], "id": "b0422904-3c96-4aee-b623-90ff6d476fe5", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "9689616cae494b", "deployed": true}], "sax.net": [200, {"circuit_id": "245385c4380f4f", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91651354100e5dcc2961'),
    '2d6348ca-1a0b-4d85-9c72-7caaa4bc01bb': '{"name": "VLAN 423", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "423"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "423"}], "id": "2d6348ca-1a0b-4d85-9c72-7caaa4bc01bb", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "0bce0016c1704f", "deployed": true}], "sax.net": [200, {"circuit_id": "ad39a263686c4d", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91671354100e5dcc2966'),
    'f680a85a-0e26-4225-95d9-ccbeebf293de': '{"name": "VLAN 424", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "424"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "424"}], "id": "f680a85a-0e26-4225-95d9-ccbeebf293de", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "f92a3540c1fa40", "deployed": true}], "sax.net": [200, {"circuit_id": "76aeb612519c49", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91681354100e5dcc296b'),
    '162f2616-6cb6-48fa-a7e1-0e2b79e91ac1': '{"name": "VLAN 425", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "425"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "425"}], "id": "162f2616-6cb6-48fa-a7e1-0e2b79e91ac1", "status": "UP", "oxp_success_count": 1, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "fe9dbdbf995f4b", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee91691354100e5dcc2970'),
    'd8c4e636-7273-4c42-b9c3-518fe6015b5b': '{"name": "VLAN 426", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "426"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "426"}], "id": "d8c4e636-7273-4c42-b9c3-518fe6015b5b", "status": "UP", "oxp_success_count": 1, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "357f021bd19342", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67ee916a1354100e5dcc2975'),
    '030c5a16-f68f-4c38-b61d-28a324bc9e31': '{"name": "VLAN 427", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "427"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "427"}], "id": "030c5a16-f68f-4c38-b61d-28a324bc9e31", "status": "UP", "oxp_success_count": 1, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "946cc4b2364844", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea0211354100e5dcc297f'),
    '05e5eb19-fce2-4b20-b418-5fc8feb79de5': '{"name": "VLAN 403", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "403"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "403"}], "id": "05e5eb19-fce2-4b20-b418-5fc8feb79de5", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "3c8ad845e41e40", "deployed": true}], "ampath.net": [200, {"circuit_id": "7548e28169c544", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea0221354100e5dcc2988'),
    '26e1a894-f3c7-4d1c-859c-54d34b6d9e44': '{"name": "VLAN 404", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "404"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "404"}], "id": "26e1a894-f3c7-4d1c-859c-54d34b6d9e44", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "407959e4188547", "deployed": true}], "sax.net": [200, {"circuit_id": "53db67bf4ec74b", "deployed": true}], "ampath.net": [200, {"circuit_id": "aa4a11901af84f", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea0241354100e5dcc2991'),
    '4a050ea8-5745-461e-a929-7137c4aaff40': '{"name": "VLAN 409", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "409"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "409"}], "id": "4a050ea8-5745-461e-a929-7137c4aaff40", "status": "UP", "oxp_success_count": 2, "oxp_response": {"sax.net": [200, {"circuit_id": "90fb67f6860441", "deployed": true}], "ampath.net": [200, {"circuit_id": "b6fbbfe9a39d47", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea0251354100e5dcc299a'),
    '0e0b376e-a7cb-44be-8ef3-ef779a516fd9': '{"name": "VLAN 410", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "410"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet02:50", "vlan": "410"}], "id": "0e0b376e-a7cb-44be-8ef3-ef779a516fd9", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "c55597ce30714f", "deployed": true}], "sax.net": [200, {"circuit_id": "4b80965945af48", "deployed": true}], "ampath.net": [200, {"circuit_id": "712fb723ad8743", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea1451354100e5dcc29b9'),
    '2e2060a1-6d8c-44b2-9dc9-c7762d0c052b': '{"name": "VLAN 405", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "405"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "405"}], "id": "2e2060a1-6d8c-44b2-9dc9-c7762d0c052b", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "22d33a3ae54f4e", "deployed": true}], "sax.net": [200, {"circuit_id": "1e26c355945040", "deployed": true}], "ampath.net": [200, {"circuit_id": "e630635ceee744", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea1471354100e5dcc29c2'),
    'febc8a1b-0376-4f5f-a034-e9addf1a55ca': '{"name": "VLAN 406", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "406"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "406"}], "id": "febc8a1b-0376-4f5f-a034-e9addf1a55ca", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "4ccb44ad72d44d", "deployed": true}], "sax.net": [200, {"circuit_id": "4feb27ad04184d", "deployed": true}], "ampath.net": [200, {"circuit_id": "b1995eb345904e", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea1491354100e5dcc29cb'),
    '53b6263c-0bfb-414d-8a93-9423c36f201d': '{"name": "VLAN 416", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "416"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "416"}], "id": "53b6263c-0bfb-414d-8a93-9423c36f201d", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "9e50dedd4f3345", "deployed": true}], "sax.net": [200, {"circuit_id": "7c78d65c96d640", "deployed": true}], "ampath.net": [200, {"circuit_id": "36688b8b19204f", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea14a1354100e5dcc29d4'),
    'f1fdc383-0852-4302-a4f4-0e07fbf980f1': '{"name": "VLAN 417", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "417"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "417"}], "id": "f1fdc383-0852-4302-a4f4-0e07fbf980f1", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "dbf9b1ca5de84d", "deployed": true}], "sax.net": [200, {"circuit_id": "cd66d4589bc44e", "deployed": true}], "ampath.net": [200, {"circuit_id": "c601c1dcb68a47", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea14c1354100e5dcc29dd'),
    '5c614b85-e4d9-43fa-913d-03d2f586bd77': '{"name": "VLAN 420", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "420"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "420"}], "id": "5c614b85-e4d9-43fa-913d-03d2f586bd77", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "6ace8096144a47", "deployed": true}], "sax.net": [200, {"circuit_id": "e5fac1a198554f", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea14d1354100e5dcc29e6'),
    '5e43a337-1bda-4551-b289-832e8cb53a94': '{"name": "VLAN 421", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "421"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "421"}], "id": "5e43a337-1bda-4551-b289-832e8cb53a94", "status": "UP", "oxp_success_count": 2, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "a87a14824a9444", "deployed": true}], "sax.net": [200, {"circuit_id": "43b41e599bcd4a", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea14e1354100e5dcc29ee'),
    '676b2557-95a3-429c-8d3f-ae0e5a691e2a': '{"name": "VLAN 411", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "411"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "411"}], "id": "676b2557-95a3-429c-8d3f-ae0e5a691e2a", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "52de8ecd9f2043", "deployed": true}], "sax.net": [200, {"circuit_id": "25c425a7bc1f48", "deployed": true}], "ampath.net": [200, {"circuit_id": "6ccf0ccfc8d94c", "deployed": true}]}}'
  },
  {
    _id: ObjectId('67eea1501354100e5dcc29f6'),
    'da6f70a6-fc11-497b-9ff1-a234805be1e7': '{"name": "VLAN 412", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "412"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "412"}], "id": "da6f70a6-fc11-497b-9ff1-a234805be1e7", "status": "UP", "oxp_success_count": 3, "oxp_response": {"tenet.ac.za": [200, {"circuit_id": "fa6eac67a91e40", "deployed": true}], "sax.net": [200, {"circuit_id": "40fd22f6ecc340", "deployed": true}], "ampath.net": [200, {"circuit_id": "4a4f96ae4e6444", "deployed": true}]}}'
  }
]
```