### PR TITLE
Fix PATCH L2VPN

### DIFF
--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -218,20 +218,23 @@ def patch_connection(service_id, body=None):  # noqa: E501
     if not connexion.request.is_json:
         return "Request body must be JSON", 400
 
-    body = L2vpnServiceIdBody.from_dict(connexion.request.get_json())  # noqa: E501
+    new_body = connexion.request.get_json()
 
-    logger.info(f"Gathered connexion JSON: {body}")
+    logger.info(f"Gathered connexion JSON: {new_body}")
 
-    body["id"] = service_id
-    logger.info(f"Request has no ID. Generated ID: {service_id}")
+    body = json.loads(value[service_id])
+    body.update(new_body)
 
     body, _ = connection_state_machine(body, ConnectionStateMachine.State.MODIFYING)
+    body["oxp_success_count"] = 0
+    db_instance.add_key_value_pair_to_db(
+        MongoCollections.CONNECTIONS, service_id, json.dumps(body)
+    )
+
     try:
         logger.info("Removing connection")
         # Get roll back connection before removing connection
-        rollback_conn_body = db_instance.read_from_db(
-            MongoCollections.CONNECTIONS, service_id
-        )
+        rollback_conn_body = value
         remove_conn_reason, remove_conn_code = connection_handler.remove_connection(
             current_app.te_manager, service_id
         )
@@ -253,18 +256,18 @@ def patch_connection(service_id, body=None):  # noqa: E501
         f"Placing new connection {service_id} with te_manager: {current_app.te_manager}"
     )
 
+    body, _ = connection_state_machine(
+        body, ConnectionStateMachine.State.UNDER_PROVISIONING
+    )
+    db_instance.add_key_value_pair_to_db(
+        MongoCollections.CONNECTIONS, service_id, json.dumps(body)
+    )
     reason, code = connection_handler.place_connection(current_app.te_manager, body)
 
     if code // 100 == 2:
-        db_instance.add_key_value_pair_to_db(
-            MongoCollections.CONNECTIONS, service_id, json.dumps(body)
-        )
         # Service created successfully
         code = 201
         logger.info(f"Placed: ID: {service_id} reason='{reason}', code={code}")
-        body, _ = connection_state_machine(
-            body, ConnectionStateMachine.State.UNDER_PROVISIONING
-        )
         response = {
             "service_id": service_id,
             "status": body["status"],


### PR DESCRIPTION
Fix #444 

Heads-up: this PR sits on top of #439 

### Description of the change

- This PR adds a fix for patching L2VPN, as documented on Issue #444.

Before the proposed changes:

```
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN between AMPATH/300 and TENET/300", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "300"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "300"}]}'
{
  "reason": "Connection published",
  "service_id": "fee63363-1190-4b5d-9975-d319c1377794",
  "status": "UNDER_PROVISIONING"
}

# wait a few seconds

$ curl -s -X PATCH -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0/fee63363-1190-4b5d-9975-d319c1377794 -d '{"name": "VLAN between AMPATH/300 and TENET/300 -- new name", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "300"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "300"}]}'
{
  "detail": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.",
  "status": 500,
  "title": "Internal Server Error",
  "type": "about:blank"
}
```

Logs before the change were provided on the issue report.

Applying the changes proposed on this PR:

```
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN between AMPATH/300 and TENET/300", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "300"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "300"}]}'
{
  "reason": "Connection published",
  "service_id": "6d731456-4a19-4a9a-982d-2416b1d09472",
  "status": "UNDER_PROVISIONING"
}

$ ./test-l2vpn-v2.sh 6d731456-4a19-4a9a-982d-2416b1d09472
Configuring hostA (h3)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 233af9eeafca199a300998035d57ef1713b67c5ce854d3748b3b2809f950e06f bash -c 'mnexec -a 172 ping6 -c5 -i0.2 2001:db8:300:300::2 '
PING 2001:db8:300:300::2(2001:db8:300:300::2) 56 data bytes
64 bytes from 2001:db8:300:300::2: icmp_seq=1 ttl=64 time=0.146 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=2 ttl=64 time=0.080 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=3 ttl=64 time=0.069 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=4 ttl=64 time=0.090 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=5 ttl=64 time=0.076 ms

--- 2001:db8:300:300::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.069/0.092/0.146/0.027 ms

$ SERVICE_ID=6d731456-4a19-4a9a-982d-2416b1d09472
$ curl -s -X PATCH -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0/$SERVICE_ID -d '{"name": "VLAN between AMPATH/300 and TENET/300 -- new name", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "300"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "300"}]}'
{
  "reason": "Connection published",
  "service_id": "6d731456-4a19-4a9a-982d-2416b1d09472",
  "status": "UNDER_PROVISIONING"
}

$ docker compose exec -it mongo1t mongosh "mongodb://192.168.0.6:27027/sdx_controller_db?directConnection=true&authSource=admin" --eval "config.set('displayBatchSize', 2000); db.connections.find({})"
[
  {
    _id: ObjectId('67eee436bd6ea86521240f00'),
    '6d731456-4a19-4a9a-982d-2416b1d09472': '{"name": "VLAN between AMPATH/300 and TENET/300 -- new name", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "300"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "300"}], "id": "6d731456-4a19-4a9a-982d-2416b1d09472", "status": "UP", "oxp_success_count": 3, "oxp_response": {"ampath.net": [200, {"circuit_id": "727cf285aaab44", "deployed": true}], "sax.net": [200, {"circuit_id": "a2c7495ae69e46", "deployed": true}], "tenet.ac.za": [200, {"circuit_id": "ecb4029443f241", "deployed": true}]}}'
  }
]

$ ./test-l2vpn-v2.sh $SERVICE_ID
Configuring hostA (h3)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 233af9eeafca199a300998035d57ef1713b67c5ce854d3748b3b2809f950e06f bash -c 'mnexec -a 172 ping6 -c5 -i0.2 2001:db8:300:300::2 '
PING 2001:db8:300:300::2(2001:db8:300:300::2) 56 data bytes
64 bytes from 2001:db8:300:300::2: icmp_seq=1 ttl=64 time=0.186 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=2 ttl=64 time=0.109 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=3 ttl=64 time=0.095 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=4 ttl=64 time=0.108 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=5 ttl=64 time=0.064 ms

--- 2001:db8:300:300::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.064/0.112/0.186/0.040 ms
```