### PR TITLE
Adding support for displaying L2VPN status according to spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@fix/sdx-controller-443",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@main",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@main",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@3.1.0.dev2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@3.1.0.dev1",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@fix/sdx-controller-443",
 ]
 
 [project.optional-dependencies]

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -11,8 +11,8 @@ from sdx_datamodel.constants import MongoCollections
 from sdx_controller.handlers.connection_handler import (
     ConnectionHandler,
     connection_state_machine,
-    parse_conn_status,
     get_connection_status,
+    parse_conn_status,
 )
 from sdx_controller.models.l2vpn_service_id_body import L2vpnServiceIdBody  # noqa: E501
 from sdx_controller.utils.db_utils import DbUtils

--- a/sdx_controller/controllers/l2vpn_controller.py
+++ b/sdx_controller/controllers/l2vpn_controller.py
@@ -11,6 +11,7 @@ from sdx_datamodel.constants import MongoCollections
 from sdx_controller.handlers.connection_handler import (
     ConnectionHandler,
     connection_state_machine,
+    parse_conn_status,
     get_connection_status,
 )
 from sdx_controller.models.l2vpn_service_id_body import L2vpnServiceIdBody  # noqa: E501
@@ -181,7 +182,7 @@ def place_connection(body):
 
     response = {
         "service_id": service_id,
-        "status": body["status"],
+        "status": parse_conn_status(body["status"]),
         "reason": reason,
     }
 
@@ -240,10 +241,14 @@ def patch_connection(service_id, body=None):  # noqa: E501
         )
 
         if remove_conn_code // 100 != 2:
+            body, _ = connection_state_machine(body, ConnectionStateMachine.State.DOWN)
+            db_instance.add_key_value_pair_to_db(
+                MongoCollections.CONNECTIONS, service_id, json.dumps(body)
+            )
             response = {
                 "service_id": service_id,
-                "status": "Failure",
-                "reason": remove_conn_reason,
+                "status": parse_conn_status(body["status"]),
+                "reason": f"Failure to modify L2VPN during removal: {remove_conn_reason}",
             }
             return response, remove_conn_code
 
@@ -270,7 +275,7 @@ def patch_connection(service_id, body=None):  # noqa: E501
         logger.info(f"Placed: ID: {service_id} reason='{reason}', code={code}")
         response = {
             "service_id": service_id,
-            "status": body["status"],
+            "status": parse_conn_status(body["status"]),
             "reason": reason,
         }
         return response, code
@@ -285,8 +290,8 @@ def patch_connection(service_id, body=None):  # noqa: E501
     if not rollback_conn_body:
         response = {
             "service_id": service_id,
-            "status": "Failure, unable to rollback to last successful L2VPN connection",
-            "reason": reason,
+            "status": parse_conn_status(body["status"]),
+            "reason": f"Failure, unable to rollback to last successful L2VPN: {reason}",
         }
         return response, code
 
@@ -311,8 +316,8 @@ def patch_connection(service_id, body=None):  # noqa: E501
 
     response = {
         "service_id": service_id,
-        "status": "Failure, rolled back to last successful L2VPN connection",
-        "reason": reason,
+        "reason": f"Failure, rolled back to last successful L2VPN: {reason}",
+        "status": parse_conn_status(conn_request["status"]),
     }
     return response, code
 

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -529,6 +529,7 @@ def get_connection_status(db, service_id: str):
         scheduling = request_dict.get("scheduling")
         notifications = request_dict.get("notifications")
         oxp_response = request_dict.get("oxp_response")
+        status = parse_conn_status(request_dict.get("status"))
         if request_dict.get("endpoints") is not None:  # spec version 2.0.0
             request_endpoints = request_dict.get("endpoints")
             request_uni_a = request_endpoints[0]
@@ -611,6 +612,7 @@ def get_connection_status(db, service_id: str):
         "endpoints": response_endpoints,
         "current_path": endpoints,
         "archived_date": 0,
+        "status": status,
     }
     if qos_metrics:
         response[service_id]["qos_metrics"] = qos_metrics
@@ -637,3 +639,23 @@ def connection_state_machine(connection, new_state):
     conn_sm.transition(new_state)
     connection["status"] = str(conn_sm.get_state())
     return connection, conn_sm
+
+
+def parse_conn_status(conn_state):
+    """Parse connection from state to status as specified on the
+    Provisioning Data Model Spec 1.0a. As per the spec:
+    - up: if the L2VPN is operational
+    - down: if the L2VPN is not operational due to topology issues/lack of path, or endpoints being down,
+    - error: when there is an error with the L2VPN,
+    - under provisioning: when the L2VPN is still being provisioned by the OXPs
+    - maintenance: when the L2VPN is being affected by a network maintenance
+    """
+    state2status = {
+        "UP": "up",
+        "UNDER_PROVISIONING": "under provisioning",
+        "RECOVERING": "down",
+        "DOWN": "down",
+        "ERROR": "down",
+        "MODIFYING": "under provisioning",
+    }
+    return state2status.get(conn_state, "error")

--- a/sdx_controller/test/test_l2vpn_controller.py
+++ b/sdx_controller/test/test_l2vpn_controller.py
@@ -338,7 +338,7 @@ class TestL2vpnController(BaseTestCase):
         assert response.status_code // 100 == 4
         self.assertEqual(
             response.get_json().get("status"),
-            "REJECTED",
+            "error",
         )
 
         # Returned connection ID should be different from the original

--- a/sdx_controller/test/test_l2vpn_controller.py
+++ b/sdx_controller/test/test_l2vpn_controller.py
@@ -388,7 +388,7 @@ class TestL2vpnController(BaseTestCase):
         assert response.status_code // 100 == 2
         self.assertEqual(
             response.get_json().get("status"),
-            "UNDER_PROVISIONING",
+            "under provisioning",
         )
         self.assertEqual(
             response.get_json().get("reason"),


### PR DESCRIPTION
Fix #437 

Heads-up: This PR should sits on top of PR #445 

### Description of the change

This PR mainly adds support for returning the L2VPN status according to Provisioning Data Model Spec 1.0a, on all operations.

I've also took the opportunity to review part of the failed PATCH L2VPN process and added a small fix for saving into the database the correct L2VPN status in case of failure to rollback.


### Local tests

After applying the changes proposed here:

```
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN between AMPATH/300 and TENET/300", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "300"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "300"}]}'
{
  "reason": "Connection published",
  "service_id": "1c48b0f2-2d49-4880-893a-f61239b7eba5",
  "status": "under provisioning"
}
$ curl http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0
{
  "1c48b0f2-2d49-4880-893a-f61239b7eba5": {
    "archived_date": 0,
    "current_path": [
      {
        "port_id": "urn:sdx:port:ampath.net:Ampath3:50",
        "vlan": "300"
      },
      {
        "port_id": "urn:sdx:port:ampath.net:Ampath1:40",
        "vlan": "1"
      },
      {
        "port_id": "urn:sdx:port:sax.net:Sax01:40",
        "vlan": "1"
      },
      {
        "port_id": "urn:sdx:port:sax.net:Sax01:41",
        "vlan": "1"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Tenet01:41",
        "vlan": "1"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50",
        "vlan": "300"
      }
    ],
    "description": null,
    "endpoints": [
      {
        "port_id": "urn:sdx:port:ampath.net:Ampath3:50",
        "vlan": "300"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50",
        "vlan": "300"
      }
    ],
    "name": "VLAN between AMPATH/300 and TENET/300",
    "oxp_response": {
      "ampath.net": [
        200,
        {
          "circuit_id": "5eb91c60a4534c",
          "deployed": true
        }
      ],
      "sax.net": [
        200,
        {
          "circuit_id": "a90a0820c89144",
          "deployed": true
        }
      ],
      "tenet.ac.za": [
        200,
        {
          "circuit_id": "e634c67920ac46",
          "deployed": true
        }
      ]
    },
    "service_id": "1c48b0f2-2d49-4880-893a-f61239b7eba5",
    "status": "up"
  }
}
$ curl http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0/cb5fb49b-71eb-4ad6-932f-505745f5ac27
{
  "cb5fb49b-71eb-4ad6-932f-505745f5ac27": {
    "archived_date": 0,
    "current_path": [
      {
        "port_id": "urn:sdx:port:ampath.net:Ampath3:50",
        "vlan": "302"
      },
      {
        "port_id": "urn:sdx:port:ampath.net:Ampath1:40",
        "vlan": "2"
      },
      {
        "port_id": "urn:sdx:port:sax.net:Sax01:40",
        "vlan": "2"
      },
      {
        "port_id": "urn:sdx:port:sax.net:Sax01:41",
        "vlan": "2"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Tenet01:41",
        "vlan": "2"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50",
        "vlan": "302"
      }
    ],
    "description": "xpto foobar",
    "endpoints": [
      {
        "port_id": "urn:sdx:port:ampath.net:Ampath3:50",
        "vlan": "302"
      },
      {
        "port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50",
        "vlan": "302"
      }
    ],
    "name": "VLAN between AMPATH/300 and TENET/300",
    "oxp_response": {
      "ampath.net": [
        200,
        {
          "circuit_id": "aded53c061ce45",
          "deployed": true
        }
      ],
      "sax.net": [
        200,
        {
          "circuit_id": "32b74f295a0e41",
          "deployed": true
        }
      ],
      "tenet.ac.za": [
        200,
        {
          "circuit_id": "f59176b5dd8444",
          "deployed": true
        }
      ]
    },
    "service_id": "cb5fb49b-71eb-4ad6-932f-505745f5ac27",
    "status": "up"
  }
}
```