### PR TITLE
bump pce version 3.1.0.dev3 => 3.1.0.dev4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pika >= 1.2.0",
     "dataset",
     "pymongo > 3.0",
-    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@3.1.0.dev3",
+    "sdx-pce @ git+https://github.com/atlanticwave-sdx/pce@3.1.0.dev4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bump PCE to 3.1.0.dev4 to incorporate recent improvements from https://github.com/atlanticwave-sdx/pce/pull/287