### PR TITLE
Using getField to fetch data from mongo collections with field names with periods

### DIFF
--- a/sdx_controller/utils/db_utils.py
+++ b/sdx_controller/utils/db_utils.py
@@ -163,7 +163,7 @@ class DbUtils(object):
         try:
             # Find document where the key exists and not marked as deleted
             result = self.sdxdb[collection].find_one(
-                {key: {"$exists": 1}, "deleted": {"$ne": True}}
+                {"$expr": {"$getField": key}, "deleted": {"$ne": True}}
             )
             return result
         except Exception as e:


### PR DESCRIPTION
Fix #465 

### Description of the change

This PR fixes a bug when retrieving data from MongoDB when the field name has "dots". Because the strategy that SDX-Controller utilizes to save topology data into MongoDB, it can lead to field names containing Periods/Dots, which is not directly supported by MongoDB (at least not using the same methodology for standard field names). On those scenarios, we have to use the operator `$getField`.