### PR TITLE
Save domain topology to mongo indexed by topology ID

### DIFF
--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -146,7 +146,7 @@ class LcMessageHandler:
         # ToDo: check if there is any change in topology update, if not, do not re-save to db.
         logger.info(f"Adding topology {domain_name} to db.")
         self.db_instance.add_key_value_pair_to_db(
-            MongoCollections.TOPOLOGIES, domain_name, json.dumps(msg_json)
+            MongoCollections.TOPOLOGIES, msg_id, json.dumps(msg_json)
         )
 
         latest_topo = json.dumps(

--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -7,6 +7,7 @@ from queue import Queue
 
 import pika
 from sdx_datamodel.constants import Constants, MessageQueueNames, MongoCollections
+from sdx_datamodel.models.topology import SDX_TOPOLOGY_ID_prefix
 
 from sdx_controller.handlers.lc_message_handler import LcMessageHandler
 from sdx_controller.utils.parse_helper import ParseHelper
@@ -114,7 +115,7 @@ class RpcConsumer(object):
         if domain_list:
             for domain in domain_list:
                 topology = db_instance.get_value_from_db(
-                    MongoCollections.TOPOLOGIES, domain
+                    MongoCollections.TOPOLOGIES, SDX_TOPOLOGY_ID_prefix + domain
                 )
 
                 if not topology:


### PR DESCRIPTION
Fix #466 

Heads-UP: this PR should sits on top of PR #464 

### Description of the change

This PR changes the strategy to index domain topologies into MongoDB to be more consistent throughout the code. Before this PR some places used the format Domain Name (e.g., `sax.net`) while others used Topology ID (e.g., `urn:sdx:topology:sax.net`). With the changes proposed here, all places will use Topology ID (e.g  `urn:sdx:topology:sax.net `)