### PR TITLE
Update to 2.0 API format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed MongoDB documents key for historical connection that must be string (#479)
 - Fixed nested documents on ports collection (#480)
+- Updated to use new Kytos API when placing connection
 
 ### Changed
 

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -40,6 +40,8 @@ class ConnectionHandler:
         port_connections_dict = (
             json.loads(port_connections_dict_json) if port_connections_dict_json else {}
         )
+        logger.info(f"PORT_ID: {port_id}")
+        logger.info(f"port_connections_dict: {port_connections_dict}")
 
         if port_id not in port_connections_dict:
             port_connections_dict[port_id] = []

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -144,7 +144,7 @@ class ConnectionHandler:
                 json.dumps(link_connections_dict),
             )
 
-            logger.debug(f"Attempting to publish domain: {domain}, link: {link}")
+            logger.debug(f"Attempting to publish domain: {domain}, link: {link_with_new_format}")
 
             # From "urn:ogf:network:sdx:topology:amlight.net", attempt to
             # extract a string like "amlight".
@@ -152,13 +152,13 @@ class ConnectionHandler:
             exchange_name = MessageQueueNames.CONNECTIONS
 
             logger.debug(
-                f"Doing '{operation}' operation for '{link}' with exchange_name: {exchange_name}, "
+                f"Doing '{operation}' operation for '{link_with_new_format}' with exchange_name: {exchange_name}, "
                 f"routing_key: {domain_name}"
             )
             mq_link = {
                 "operation": operation,
                 "service_id": connection_service_id,
-                "link": link,
+                "link": link_with_new_format,
             }
             producer = TopicQueueProducer(
                 timeout=5, exchange_name=exchange_name, routing_key=domain_name

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -569,7 +569,7 @@ class ConnectionHandler:
                     logger.debug(f"Connection status updated for {service_id}")
             else:
                 logger.warning(
-                    f"port not found in db {port.id} in {port_connections_dict}"
+                    f"Port not found in db {port.id} in {port_connections_dict}"
                 )
 
     def handle_uni_ports_down_to_up(self, uni_ports_down_to_up):

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -167,7 +167,9 @@ class ConnectionHandler:
                 link_with_new_format["name"] = link.get("name", "")
                 link_with_new_format["endpoints"] = []
                 for port in port_list:
-                    self._process_port(connection_service_id, port.get("port_id"), operation)
+                    self._process_port(
+                        connection_service_id, port.get("port_id"), operation
+                    )
                     if port.get("vlan_value"):
                         link_with_new_format["endpoints"].append(
                             {

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -327,7 +327,7 @@ class ConnectionHandler:
             MongoCollections.HISTORICAL_CONNECTIONS, service_id
         )
         # Current timestamp in seconds
-        timestamp = int(time.time())
+        timestamp = str(int(time.time()))
 
         if historical_connections_list:
             historical_connections_list.append({timestamp: connection_request})
@@ -340,7 +340,7 @@ class ConnectionHandler:
             self.db_instance.add_key_value_pair_to_db(
                 MongoCollections.HISTORICAL_CONNECTIONS,
                 service_id,
-                [{str(timestamp): connection_request}],
+                [{timestamp: connection_request}],
             )
         logger.debug(f"Archived connection: {service_id}")
 

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -40,8 +40,6 @@ class ConnectionHandler:
         port_connections_dict = (
             json.loads(port_connections_dict_json) if port_connections_dict_json else {}
         )
-        logger.info(f"PORT_ID: {port_id}")
-        logger.info(f"port_connections_dict: {port_connections_dict}")
 
         if port_id not in port_connections_dict:
             port_connections_dict[port_id] = []
@@ -169,7 +167,7 @@ class ConnectionHandler:
                 link_with_new_format["name"] = link.get("name", "")
                 link_with_new_format["endpoints"] = []
                 for port in port_list:
-                    self._process_port(connection_service_id, port, operation)
+                    self._process_port(connection_service_id, port.get("port_id"), operation)
                     if port.get("vlan_value"):
                         link_with_new_format["endpoints"].append(
                             {

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -144,7 +144,9 @@ class ConnectionHandler:
                 json.dumps(link_connections_dict),
             )
 
-            logger.debug(f"Attempting to publish domain: {domain}, link: {link_with_new_format}")
+            logger.debug(
+                f"Attempting to publish domain: {domain}, link: {link_with_new_format}"
+            )
 
             # From "urn:ogf:network:sdx:topology:amlight.net", attempt to
             # extract a string like "amlight".

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -329,8 +329,17 @@ class ConnectionHandler:
         connection_request = self.db_instance.get_value_from_db(
             MongoCollections.CONNECTIONS, service_id
         )
+        
         if not connection_request:
             return "Did not find connection request, cannot remove connection", 404
+
+        oxp_response = connection_request.get("oxp_response")
+        
+        # evc_id is the service_id in the OXP response, it differs from the service_id in the connection.
+        evc_id = oxp_response.get("service_id", None) if oxp_response else None
+
+        if not oxp_response or not evc_id:
+            return "Connection does not have OXP response, cannot remove connection", 404
 
         breakdown = self.db_instance.get_value_from_db(
             MongoCollections.BREAKDOWNS, service_id
@@ -339,6 +348,7 @@ class ConnectionHandler:
             return "Did not find breakdown, cannot remove connection", 404
 
         try:
+            breakdown["evc_id"] = evc_id
             status, code = self._send_breakdown_to_lc(
                 breakdown, "delete", connection_request
             )

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -163,7 +163,6 @@ class ConnectionHandler:
             producer = TopicQueueProducer(
                 timeout=5, exchange_name=exchange_name, routing_key=domain_name
             )
-            logger.info(f"link_with_new_format: {link_with_new_format}")
             producer.call(json.dumps(mq_link))
             producer.stop_keep_alive()
 

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -100,22 +100,27 @@ class ConnectionHandler:
             link_with_new_format = {}
             for key in link.keys():
                 if "uni_" in key and "port_id" in link[key]:
-                    port_list.append(link[key]["port_id"])
+                    port_list.append(
+                        {
+                            "port_id": link[key]["port_id"],
+                            "vlan_value": link[key].get("tag", {}).get("value"),
+                        }
+                    )
 
             if port_list:
                 link_with_new_format["name"] = link.get("name", "")
                 link_with_new_format["endpoints"] = []
                 for port in port_list:
                     self._process_port(connection_service_id, port, operation)
-                    vlan_value = link.get("tag", {}).get("value")
-                    if vlan_value is not None:
+                    if port.get("vlan_value"):
                         link_with_new_format["endpoints"].append(
                             {
-                                "port_id": port,
-                                "vlan": str(vlan_value),
+                                "port_id": port.get("port_id"),
+                                "vlan": port.get("vlan_value"),
                             }
                         )
-                simple_link = SimpleLink(port_list).to_string()
+                port_id_list = [port.get("port_id") for port in port_list]
+                simple_link = SimpleLink(port_id_list).to_string()
 
             self._process_link_connection_dict(
                 link_connections_dict, simple_link, connection_service_id, operation

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -329,17 +329,20 @@ class ConnectionHandler:
         connection_request = self.db_instance.get_value_from_db(
             MongoCollections.CONNECTIONS, service_id
         )
-        
+
         if not connection_request:
             return "Did not find connection request, cannot remove connection", 404
 
         oxp_response = connection_request.get("oxp_response")
-        
+
         # evc_id is the service_id in the OXP response, it differs from the service_id in the connection.
         evc_id = oxp_response.get("service_id", None) if oxp_response else None
 
         if not oxp_response or not evc_id:
-            return "Connection does not have OXP response, cannot remove connection", 404
+            return (
+                "Connection does not have OXP response, cannot remove connection",
+                404,
+            )
 
         breakdown = self.db_instance.get_value_from_db(
             MongoCollections.BREAKDOWNS, service_id

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -167,7 +167,11 @@ class ConnectionHandler:
                 oxp_response = connection_request.get("oxp_response")
 
                 # evc_id is the service_id in the OXP response, it differs from the service_id in the connection.
-                evc_id = oxp_response.get(domain_name, [None, {}])[1].get("service_id") if oxp_response else None
+                evc_id = (
+                    oxp_response.get(domain_name, [None, {}])[1].get("service_id")
+                    if oxp_response
+                    else None
+                )
 
                 if not oxp_response or not evc_id:
                     return (
@@ -184,7 +188,9 @@ class ConnectionHandler:
 
         # We will get to this point only if all the previous steps
         # leading up to this point were successful.
-        return "Connection deleted" if operation == "delete" else "Connection published", 201
+        return (
+            "Connection deleted" if operation == "delete" else "Connection published"
+        ), 201
 
     def place_connection(
         self, te_manager: TEManager, connection_request: dict

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -93,6 +93,9 @@ class LcMessageHandler:
                     != str(ConnectionStateMachine.State.ERROR)
                 ):
                     connection, _ = connection_state_machine(
+                        connection, ConnectionStateMachine.State.MODIFYING
+                    )
+                    connection, _ = connection_state_machine(
                         connection, ConnectionStateMachine.State.DOWN
                     )
 

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -85,12 +85,6 @@ class LcMessageHandler:
                     connection, _ = connection_state_machine(
                         connection, ConnectionStateMachine.State.ERROR
                     )
-                elif connection.get("status") == str(
-                    ConnectionStateMachine.State.UNDER_PROVISIONING
-                ):
-                    connection, _ = connection_state_machine(
-                        connection, ConnectionStateMachine.State.DOWN
-                    )
                 elif (
                     connection.get("status")
                     and connection.get("status")
@@ -98,9 +92,6 @@ class LcMessageHandler:
                     and connection.get("status")
                     != str(ConnectionStateMachine.State.ERROR)
                 ):
-                    connection, _ = connection_state_machine(
-                        connection, ConnectionStateMachine.State.MODIFYING
-                    )
                     connection, _ = connection_state_machine(
                         connection, ConnectionStateMachine.State.DOWN
                     )

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -85,6 +85,12 @@ class LcMessageHandler:
                     connection, _ = connection_state_machine(
                         connection, ConnectionStateMachine.State.ERROR
                     )
+                elif connection.get("status") == str(
+                    ConnectionStateMachine.State.UNDER_PROVISIONING
+                ):
+                    connection, _ = connection_state_machine(
+                        connection, ConnectionStateMachine.State.DOWN
+                    )
                 elif (
                     connection.get("status")
                     and connection.get("status")


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-lc/issues/190

Convert pce 1.0 format to 2.0 format before sending to LCs. Example:

```
{'name': 'TENET_vlan_1_4095', 'endpoints': [{'port_id': 'urn:sdx:port:tenet.ac.za:Novi07:1', 'vlan': 1}, {'port_id': 'urn:sdx:port:tenet.ac.za:Novi08:44', 'vlan': 4095}]}
```