### PR TITLE
Fixed documents key for collection historical_connections that must be string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - Unreleased
+
+### Added
+
+- TODO
+
+### Fixed
+
+- Fixed MongoDB documents key for historical connection that must be string (#479)
+
+### Changed
+
+- TODO
+
+
 ## [2.0.0] - 2023-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sdx-controller"
-version = "3.1.0.dev1"
+version = "3.1.0.dev2"
 description = "AtlanticWave-SDX project's main controller"
 authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -290,7 +290,7 @@ class ConnectionHandler:
             MongoCollections.HISTORICAL_CONNECTIONS, service_id
         )
         # Current timestamp in seconds
-        timestamp = int(time.time())
+        timestamp = str(int(time.time()))
 
         if historical_connections_list:
             historical_connections_list.append({timestamp: connection_request})


### PR DESCRIPTION
Fix #479 

## Description of the change

The collection `historical_connections` was adding information with document keys being an integer (timestamp) while MongoDB only accept document keys to be string. This PR fixes the error.

## End-to-End test results

Here are the setup and results from the end-to-end tests:
```
~/sdx-end-to-end-tests$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   docker-compose.yml

~/sdx-end-to-end-tests$ git diff docker-compose.yml
diff --git a/docker-compose.yml b/docker-compose.yml
index 8b430f2..8a5d4b3 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./sdx-controller/sdx_controller:/opt/venv/lib/python3.11/site-packages/sdx_controller
     depends_on:
       mongo:
         condition: service_healthy
~/sdx-end-to-end-tests/sdx-controller$ git status
On branch fix/issue_479
Your branch is up to date with 'origin/fix/issue_479'.

nothing to commit, working tree clean
~/sdx-end-to-end-tests/sdx-controller$ git log -1
commit 49abd2cb01a45587886f4223067a89ecb46031f2 (HEAD -> fix/issue_479, origin/fix/issue_479)
Author: Italo Valcy <italo@ampath.net>
Date:   Thu Aug 21 11:46:53 2025 -0300

    fixed documents key for collection historical_connections that must be string
~/sdx-end-to-end-tests$ cat result-e2e.log
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack
rootdir: /sdx-end-to-end-tests
plugins: unordered-0.7.0
collected 95 items

tests/test_01_topology.py .....                                          [  5%]
tests/test_05_l2vpn.py ........                                          [ 13%]
tests/test_06_l2vpn_return_codes.py ..................................   [ 49%]
tests/test_07_l2vpn_return_codes.py .......................              [ 73%]
tests/test_08_l2vpn_return_codes.py ......                               [ 80%]
tests/test_20_use_case_topology.py xx.x.xx....x                          [ 92%]
tests/test_21_use_case_topology.py x.xx                                  [ 96%]
tests/test_99_topology_big_changes.py ...                                [100%]

------------------------------- start/stop times -------------------------------
================== 86 passed, 9 xfailed in 1673.76s (0:27:53) ==================
```