### PR TITLE
Fix nested documents on ports collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed MongoDB documents key for historical connection that must be string (#479)
+- Fixed nested documents on ports collection (#480)
 
 ### Changed
 

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -32,7 +32,7 @@ class ConnectionHandler:
         self.parse_helper = ParseHelper()
 
     def _process_port(self, connection_service_id, port_id, operation):
-        port_in_db = self.db_instance.read_from_db(MongoCollections.PORTS, port_id)
+        port_in_db = self.db_instance.get_value_from_db(MongoCollections.PORTS, port_id)
 
         if not port_in_db:
             port_in_db = {}


### PR DESCRIPTION
Fix #480 

### Description of the change

- replace read_from_db with get_value_from_db to avoid nested documents on PORTs collection for a certain port_id

### Local tests

After apply the same steps documented on Issue #480 to reproduce this issue, but with the fix applied, I dont see the errors in the log anymore, as well as the MongoDB ports collections seems correct now:

```
$ for i in $(seq 1 100); do echo $i $(date); docker compose exec -it mininet curl -s -X POST -H 'Content-type: application/json' http://sdx-controller:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "vlan test '$i'", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "'$i'"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "'$i'"}]}'; done

# wait until all L2VPN to be provisioned 

$ docker compose exec -i mininet curl -s http://sdx-controller:8080/SDX-Controller/l2vpn/1.0 | jq -r '.[]|.service_id + " " + .status' | grep -c up
100

$ docker compose logs sdx-controller -t | grep -c ERROR
0

$ docker compose exec -i mininet curl -s http://sdx-controller:8080/SDX-Controller/l2vpn/1.0 | jq -r '.[].service_id' > /tmp/bla
$ for cada in $(cat /tmp/bla); do docker compose exec -it mininet curl -s -X DELETE http://sdx-controller:8080/SDX-Controller/l2vpn/1.0/$cada; done

$ docker compose logs sdx-controller -t | grep -c ERROR
0

$ docker compose exec -it mongo mongosh "mongodb://sdxctl_user:****@mongo:27017/?authSource=sdxctldb"
test> use sdxctldb
switched to db sdxctldb
sdxctldb> db.ports.find()
[
  {
    _id: ObjectId('68a8b93a1c7dd0cea9a10047'),
    'urn:sdx:port:ampath.net:Ampath3:50': { port_connections_dict: [] }
  },
  {
    _id: ObjectId('68a8b93a1c7dd0cea9a10048'),
    'urn:sdx:port:ampath.net:Ampath1:40': { port_connections_dict: [] }
  },
  {
    _id: ObjectId('68a8b93a1c7dd0cea9a1004a'),
    'urn:sdx:port:sax.net:Sax01:40': { port_connections_dict: [] }
  },
  {
    _id: ObjectId('68a8b93a1c7dd0cea9a1004b'),
    'urn:sdx:port:sax.net:Sax01:50': { port_connections_dict: [] }
  }
]
sdxctldb>
```

Then I create 10 additional L2VPNs (and do NOT deleted them) to test:
```
$ for i in $(seq 1 10); do echo $i $(date); docker compose exec -it mininet curl -s -X POST -H 'Content-type: application/json' http://sdx-controller:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "vlan test '$i'", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "'$i'"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "'$i'"}]}'; done
...

$ docker compose exec -it mongo mongosh "mongodb://sdxctl_user:*****@mongo:27017/?authSource=sdxctldb"

test> use sdxctldb
switched to db sdxctldb
sdxctldb> db.ports.find()
[
  {
    _id: ObjectId('68a8b93a1c7dd0cea9a10047'),
    'urn:sdx:port:ampath.net:Ampath3:50': {
      port_connections_dict: [
        '493998d0-9ccb-4e6d-be5b-964ba1ccd688',
        'f7032e23-11ac-495f-947d-bdcf6e723a40',
        'cd6aa473-2f19-472c-864e-4ff054de3b48',
        'f367b79e-ef45-451b-9ce8-6152cefacd18',
        '165bc32b-ffa4-415e-9965-13e42028a05c',
        'bac5365d-533d-4151-9206-c9b887f2fed0',
        'f2a22988-fadd-4a10-8c44-3637a44fe753',
        'fe09efe2-e768-43ce-90c9-9478aebc163e',
        '398c2cca-23ef-4d55-9040-ee5d351763f6',
        '0fcf0e3b-f9e0-4f9c-aff7-8cf027532acc'
      ]
    }
  },
  {
    _id: ObjectId('68a8b93a1c7dd0cea9a10048'),
    'urn:sdx:port:ampath.net:Ampath1:40': {
      port_connections_dict: [
        '493998d0-9ccb-4e6d-be5b-964ba1ccd688',
        'f7032e23-11ac-495f-947d-bdcf6e723a40',
        'cd6aa473-2f19-472c-864e-4ff054de3b48',
        'f367b79e-ef45-451b-9ce8-6152cefacd18',
        '165bc32b-ffa4-415e-9965-13e42028a05c',
        'bac5365d-533d-4151-9206-c9b887f2fed0',
        'f2a22988-fadd-4a10-8c44-3637a44fe753',
        'fe09efe2-e768-43ce-90c9-9478aebc163e',
        '398c2cca-23ef-4d55-9040-ee5d351763f6',
        '0fcf0e3b-f9e0-4f9c-aff7-8cf027532acc'
      ]
    }
  },
  {
    _id: ObjectId('68a8b93a1c7dd0cea9a1004a'),
    'urn:sdx:port:sax.net:Sax01:40': {
      port_connections_dict: [
        '493998d0-9ccb-4e6d-be5b-964ba1ccd688',
        'f7032e23-11ac-495f-947d-bdcf6e723a40',
        'cd6aa473-2f19-472c-864e-4ff054de3b48',
        'f367b79e-ef45-451b-9ce8-6152cefacd18',
        '165bc32b-ffa4-415e-9965-13e42028a05c',
        'bac5365d-533d-4151-9206-c9b887f2fed0',
        'f2a22988-fadd-4a10-8c44-3637a44fe753',
        'fe09efe2-e768-43ce-90c9-9478aebc163e',
        '398c2cca-23ef-4d55-9040-ee5d351763f6',
        '0fcf0e3b-f9e0-4f9c-aff7-8cf027532acc'
      ]
    }
  },
  {
    _id: ObjectId('68a8b93a1c7dd0cea9a1004b'),
    'urn:sdx:port:sax.net:Sax01:50': {
      port_connections_dict: [
        '493998d0-9ccb-4e6d-be5b-964ba1ccd688',
        'f7032e23-11ac-495f-947d-bdcf6e723a40',
        'cd6aa473-2f19-472c-864e-4ff054de3b48',
        'f367b79e-ef45-451b-9ce8-6152cefacd18',
        '165bc32b-ffa4-415e-9965-13e42028a05c',
        'bac5365d-533d-4151-9206-c9b887f2fed0',
        'f2a22988-fadd-4a10-8c44-3637a44fe753',
        'fe09efe2-e768-43ce-90c9-9478aebc163e',
        '398c2cca-23ef-4d55-9040-ee5d351763f6',
        '0fcf0e3b-f9e0-4f9c-aff7-8cf027532acc'
      ]
    }
  }
]
sdxctldb>
```

### End-to-end tests

```
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack
rootdir: /sdx-end-to-end-tests
plugins: unordered-0.7.0
collected 95 items

tests/test_01_topology.py .....                                          [  5%]
tests/test_05_l2vpn.py ........                                          [ 13%]
tests/test_06_l2vpn_return_codes.py ..................................   [ 49%]
tests/test_07_l2vpn_return_codes.py .......................              [ 73%]
tests/test_08_l2vpn_return_codes.py ......                               [ 80%]
tests/test_20_use_case_topology.py xx.x.xx....x                          [ 92%]
tests/test_21_use_case_topology.py x.xx                                  [ 96%]
tests/test_99_topology_big_changes.py ...                                [100%]

------------------------------- start/stop times -------------------------------
================== 86 passed, 9 xfailed in 1676.98s (0:27:56) ==================
```