### PR TITLE
Update default HEARTBEAT_INTERVAL to 30

### DIFF
--- a/sdx_controller/messaging/rpc_queue_consumer.py
+++ b/sdx_controller/messaging/rpc_queue_consumer.py
@@ -32,7 +32,7 @@ MQ_HOST = os.getenv("MQ_HOST")
 MQ_PORT = os.getenv("MQ_PORT") or 5672
 MQ_USER = os.getenv("MQ_USER") or "guest"
 MQ_PASS = os.getenv("MQ_PASS") or "guest"
-HEARTBEAT_INTERVAL = int(os.getenv("HEARTBEAT_INTERVAL", 10))  # seconds
+HEARTBEAT_INTERVAL = int(os.getenv("HEARTBEAT_INTERVAL", 30))  # seconds
 HEARTBEAT_TOLERANCE = int(
     os.getenv("HEARTBEAT_TOLERANCE", 3)
 )  # consecutive missed heartbeats allowed


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/505

The LC's HEARTBEAT_INTERVAL default value is 30, changing SDX controller's default value to 30 to be consistent. 10 seconds heart beat might be too aggressive.