### PR TITLE
Recover error connection when SDX domain becomes UP

### DIFF
--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -61,7 +61,9 @@ class ConnectionHandler:
         logger.info(f"Saved connection {service_id} to error collection")
 
     def delete_error_connection(self, service_id) -> None:
-        self.db_instance.delete_one_entry(MongoCollections.ERROR_CONNECTIONS, service_id)
+        self.db_instance.delete_one_entry(
+            MongoCollections.ERROR_CONNECTIONS, service_id
+        )
 
     def get_latest_archived_connection(self, service_id):
         historical_connections = self.db_instance.get_value_from_db(

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -34,6 +34,117 @@ class ConnectionHandler:
         self.db_instance = db_instance
         self.parse_helper = ParseHelper()
 
+    def save_error_connection(self, connection, reason, details=None) -> None:
+        if not connection:
+            return
+
+        service_id = connection.get("id")
+        if not service_id:
+            return
+
+        connection_to_save = dict(connection)
+        connection_to_save["status"] = str(ConnectionStateMachine.State.ERROR)
+
+        error_record = {
+            "connection": connection_to_save,
+            "reason": reason,
+            "updated_at": str(int(time.time())),
+        }
+        if details is not None:
+            error_record["details"] = details
+
+        self.db_instance.add_key_value_pair_to_db(
+            MongoCollections.ERROR_CONNECTIONS,
+            service_id,
+            error_record,
+        )
+        logger.info(f"Saved connection {service_id} to error collection")
+
+    def delete_error_connection(self, service_id) -> None:
+        self.db_instance.delete_one_entry(MongoCollections.ERROR_CONNECTIONS, service_id)
+
+    def get_latest_archived_connection(self, service_id):
+        historical_connections = self.db_instance.get_value_from_db(
+            MongoCollections.HISTORICAL_CONNECTIONS, service_id
+        )
+        if not historical_connections:
+            return None, None
+
+        latest_record = historical_connections[-1]
+        if not latest_record:
+            return None, None
+
+        latest_timestamp = next(reversed(latest_record))
+        latest_entry = latest_record.get(latest_timestamp, {})
+        return latest_entry.get("connection"), latest_entry.get("reason")
+
+    def save_error_connection_from_archive(
+        self, service_id, reason, details=None, expected_archive_reason=None
+    ) -> bool:
+        connection, archive_reason = self.get_latest_archived_connection(service_id)
+        if not connection:
+            return False
+
+        if (
+            expected_archive_reason is not None
+            and archive_reason != expected_archive_reason
+        ):
+            return False
+
+        self.save_error_connection(connection, reason=reason, details=details)
+        return True
+
+    def retry_error_connections(self, te_manager) -> None:
+        error_connections = self.db_instance.get_all_entries_in_collection(
+            MongoCollections.ERROR_CONNECTIONS
+        )
+
+        for error_connection in error_connections:
+            service_id = next(iter(error_connection))
+            error_record = error_connection.get(service_id, {})
+            connection = error_record.get("connection", error_record)
+
+            if not connection:
+                continue
+
+            active_connection = self.db_instance.get_value_from_db(
+                MongoCollections.CONNECTIONS, service_id
+            )
+            if active_connection:
+                active_status = active_connection.get("status")
+                if active_status in {
+                    str(ConnectionStateMachine.State.RECOVERING),
+                    str(ConnectionStateMachine.State.UNDER_PROVISIONING),
+                    str(ConnectionStateMachine.State.UP),
+                    str(ConnectionStateMachine.State.MODIFYING),
+                }:
+                    logger.info(
+                        f"Skipping retry for {service_id}; active status is {active_status}"
+                    )
+                    continue
+                connection = active_connection
+
+            connection_to_retry = dict(connection)
+            connection_to_retry["status"] = str(ConnectionStateMachine.State.RECOVERING)
+            connection_to_retry["oxp_success_count"] = 0
+            connection_to_retry.pop("oxp_response", None)
+
+            self.db_instance.add_key_value_pair_to_db(
+                MongoCollections.CONNECTIONS, service_id, connection_to_retry
+            )
+
+            reason, code = self.place_connection(te_manager, connection_to_retry)
+            logger.info(
+                f"Retry error connection result: ID: {service_id} reason='{reason}', code={code}"
+            )
+
+            if code // 100 != 2:
+                self.save_error_connection(
+                    connection_to_retry,
+                    reason="Retry failed",
+                    details={"place_connection_reason": reason, "code": code},
+                )
+
     def _process_port(self, connection_service_id, port_id, operation):
         port_connections_dict_json = self.db_instance.get_value_from_db(
             MongoCollections.PORTS, Constants.PORT_CONNECTIONS_DICT
@@ -507,11 +618,21 @@ class ConnectionHandler:
                             te_manager, connection["id"], archive_reason="Failure"
                         )
                         if code // 100 != 2:
+                            self.save_error_connection(
+                                connection,
+                                reason="Failure handling delete failed",
+                                details={"code": code},
+                            )
                             logger.info(
                                 f"Do not remove connection, may be already removed: {connection['id']}, code: {code}"
                             )
                             continue
                     except Exception as err:
+                        self.save_error_connection(
+                            connection,
+                            reason="Failure handling delete raised exception",
+                            details={"error": str(err)},
+                        )
                         logger.info(
                             f"Encountered error when deleting connection: {err}"
                         )
@@ -535,6 +656,11 @@ class ConnectionHandler:
                             MongoCollections.CONNECTIONS,
                             service_id,
                             connection,
+                        )
+                        self.save_error_connection(
+                            connection,
+                            reason="Failure handling recovery failed",
+                            details={"place_connection_reason": _reason, "code": code},
                         )
 
                     logger.info(

--- a/sdx_controller/handlers/connection_handler.py
+++ b/sdx_controller/handlers/connection_handler.py
@@ -139,6 +139,10 @@ class ConnectionHandler:
             )
 
             if code // 100 != 2:
+                connection_to_retry["status"] = str(ConnectionStateMachine.State.ERROR)
+                self.db_instance.add_key_value_pair_to_db(
+                    MongoCollections.CONNECTIONS, service_id, connection_to_retry
+                )
                 self.save_error_connection(
                     connection_to_retry,
                     reason="Retry failed",

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -147,10 +147,24 @@ class LcMessageHandler:
         logger.info("Save to database complete.")
         logger.info("message ID:" + str(db_msg_id))
 
+        previous_domain_status = domain_dict.get(domain_name)
         is_new_domain = domain_name not in domain_dict
+        is_recovered_domain = (
+            previous_domain_status is not None
+            and previous_domain_status != DomainStatus.UP
+        )
 
         # Update existing topology
         if domain_name in domain_dict:
+            if is_recovered_domain:
+                logger.info(
+                    f"Domain {domain_name} status changed from "
+                    f"{previous_domain_status} to {DomainStatus.UP}"
+                )
+                domain_dict[domain_name] = DomainStatus.UP
+                self.db_instance.add_key_value_pair_to_db(
+                    MongoCollections.DOMAINS, Constants.DOMAIN_DICT, domain_dict
+                )
             logger.info("Updating topo")
             logger.debug(msg_json)
             (
@@ -205,6 +219,6 @@ class LcMessageHandler:
         self.db_instance.add_key_value_pair_to_db(
             MongoCollections.TOPOLOGIES, Constants.LATEST_TOPOLOGY, latest_topo
         )
-        if is_new_domain:
+        if is_new_domain or is_recovered_domain:
             self.connection_handler.retry_error_connections(self.te_manager)
         logger.info("Save to database complete.")

--- a/sdx_controller/handlers/lc_message_handler.py
+++ b/sdx_controller/handlers/lc_message_handler.py
@@ -32,6 +32,9 @@ class LcMessageHandler:
         if msg_json.get("msg_type") and msg_json["msg_type"] == "oxp_conn_response":
             logger.info("Received OXP connection response.")
             service_id = msg_json.get("service_id")
+            operation = msg_json.get("operation")
+            oxp_response_code = msg_json.get("oxp_response_code")
+            oxp_response_msg = msg_json.get("oxp_response")
 
             if not service_id:
                 return
@@ -41,6 +44,20 @@ class LcMessageHandler:
             )
 
             if not connection:
+                if operation == "delete" and oxp_response_code // 100 != 2:
+                    saved = self.connection_handler.save_error_connection_from_archive(
+                        service_id,
+                        reason="Delete failed during failure handling",
+                        details={
+                            "oxp_response_code": oxp_response_code,
+                            "oxp_response": oxp_response_msg,
+                        },
+                        expected_archive_reason="Failure",
+                    )
+                    if saved:
+                        logger.info(
+                            f"Saved archived connection {service_id} to error collection after delete failure"
+                        )
                 return
 
             breakdown = self.db_instance.get_value_from_db(
@@ -53,8 +70,6 @@ class LcMessageHandler:
             oxp_number = len(breakdown)
             oxp_success_count = connection.get("oxp_success_count", 0)
             lc_domain = msg_json.get("lc_domain")
-            oxp_response_code = msg_json.get("oxp_response_code")
-            oxp_response_msg = msg_json.get("oxp_response")
             oxp_response = connection.get("oxp_response")
             if not oxp_response:
                 oxp_response = {}
@@ -62,7 +77,7 @@ class LcMessageHandler:
             connection["oxp_response"] = oxp_response
 
             if oxp_response_code // 100 == 2:
-                if msg_json.get("operation") != "delete":
+                if operation != "delete":
                     oxp_success_count += 1
                     connection["oxp_success_count"] = oxp_success_count
                     if oxp_success_count == oxp_number:
@@ -77,7 +92,17 @@ class LcMessageHandler:
                         connection, _ = connection_state_machine(
                             connection, ConnectionStateMachine.State.UP
                         )
+                        self.connection_handler.delete_error_connection(service_id)
             else:
+                if operation == "delete":
+                    self.connection_handler.save_error_connection(
+                        connection,
+                        reason="Delete failed during failure handling",
+                        details={
+                            "oxp_response_code": oxp_response_code,
+                            "oxp_response": oxp_response_msg,
+                        },
+                    )
                 if connection.get("status") and (
                     connection.get("status")
                     == str(ConnectionStateMachine.State.RECOVERING)
@@ -121,6 +146,8 @@ class LcMessageHandler:
         )
         logger.info("Save to database complete.")
         logger.info("message ID:" + str(db_msg_id))
+
+        is_new_domain = domain_name not in domain_dict
 
         # Update existing topology
         if domain_name in domain_dict:
@@ -178,4 +205,6 @@ class LcMessageHandler:
         self.db_instance.add_key_value_pair_to_db(
             MongoCollections.TOPOLOGIES, Constants.LATEST_TOPOLOGY, latest_topo
         )
+        if is_new_domain:
+            self.connection_handler.retry_error_connections(self.te_manager)
         logger.info("Save to database complete.")


### PR DESCRIPTION
Relates to: https://github.com/atlanticwave-sdx/datamodel/pull/205
Resolves: https://github.com/atlanticwave-sdx/sdx-controller/issues/527

If new domain joins, or domain status becomes "UP" again, sdx controller will go through all archived error connections, attempt to recover these connections.